### PR TITLE
Check that submodel predictions are unique per .config

### DIFF
--- a/tests/testthat/test-mars-tuning.R
+++ b/tests/testthat/test-mars-tuning.R
@@ -12,6 +12,8 @@ data_folds <- vfold_cv(two_class_dat, repeats = 3)
 
 test_that("tuning for mars() -- submodels *and* no submodels", {
 
+  skip_if(utils::packageVersion("tune") <= "0.1.1")
+
   expect_error(
     mars_spec <-
       mars(num_terms = tune(), prod_degree = tune(), prune_method = tune()) %>%

--- a/tests/testthat/test-mars-tuning.R
+++ b/tests/testthat/test-mars-tuning.R
@@ -57,7 +57,8 @@ test_that("tuning for mars() -- submodels *and* no submodels", {
       mars_wf,
       resample = data_folds,
       grid = params_grid,
-      metrics = metric_set(roc_auc)
+      metrics = metric_set(roc_auc),
+      control = control_grid(save_pred = TRUE)
     ),
     NA
   )
@@ -66,6 +67,9 @@ test_that("tuning for mars() -- submodels *and* no submodels", {
   expect_equal(mars_metrics$.config, paste0("Model", 1:7))
   expect_equal(unique(mars_metrics$.metric), "roc_auc")
   expect_true(all(names(params_grid) %in% names(mars_metrics)))
+
+  expect_error(mars_preds <- collect_predictions(rs, summarize = TRUE), NA)
+  expect_equal(count(mars_preds, .row, .config)$n, rep(1L, 5537))
 
 })
 


### PR DESCRIPTION
This expands the tests for the tuning submodel case to make sure that predictions are unique per row and config, i.e. that `.config` was set correctly. This PR addresses tidymodels/tune#258.

I did find one failure locally here, but I don't _think_ it's related:

```
test-encodings-glmnet.R:80: failure: workflows
`predict(parsnip_wflow_fit, ames %>% select(Year_Built, Alley))` threw an error.
Message: error in evaluating the argument 'x' in selecting a method for function 'as.matrix': Cholmod error 'X and/or Y have wrong dimensions' at file ../MatrixOps/cholmod_sdmult.c, line 90
Class:   simpleError/error/condition
Backtrace:
  1. testthat::expect_error(...) tests/testthat/test-encodings-glmnet.R:80:2
 22. base::.handleSimpleError(...)
 23. base:::h(simpleError(msg, call))
```