### PR TITLE
Parallel tests for 

### DIFF
--- a/tests/testthat/test-S3-registration.R
+++ b/tests/testthat/test-S3-registration.R
@@ -9,6 +9,19 @@ test_recipe <-
   recipe(mpg ~ ., data = mtcars) %>%
   step_pls(all_predictors(), outcome = "mpg")
 
+test_mod <-
+  linear_reg() %>%
+  set_engine("glmnet")
+
+test_rec_wflow <-
+  workflow() %>%
+  add_model(test_mod) %>%
+  add_recipe(test_recipe)
+
+test_form_wflow <-
+  workflow() %>%
+  add_model(test_mod) %>%
+  add_formula(y ~ .)
 
 # ------------------------------------------------------------------------------
 
@@ -24,4 +37,17 @@ test_that('recipe required_pkgs methods', {
   pls_pkgs <- required_pkgs(test_recipe, FALSE)
 
   expect_equal(pls_pkgs, "mixOmics")
+})
+
+
+test_that('workflows required_pkgs methods', {
+  skip_if(utils::packageVersion("tune") < "0.1.1.9000")
+  skip_if(utils::packageVersion("recipes") < "0.1.13.9000")
+
+  rec_pkgs <- required_pkgs(test_rec_wflow, FALSE)
+  expect_equal(rec_pkgs, c("glmnet", "mixOmics"))
+
+  form_pkgs <- required_pkgs(test_form_wflow, FALSE)
+  expect_equal(form_pkgs, "glmnet")
+
 })


### PR DESCRIPTION
See also tidymodels/tune#265. 

This PR includes unit tests for tidymodels/recipes#558 since they depend on `tune`