### PR TITLE
Test for glmnet x/y column order predictions

### DIFF
--- a/tests/testthat/test-glmnet-linear.R
+++ b/tests/testthat/test-glmnet-linear.R
@@ -86,6 +86,10 @@ test_that('glmnet prediction, single lambda', {
                 198.126819755653)
 
   expect_equal(uni_pred, predict(res_xy, hpc[1:5, num_pred])$.pred, tolerance = 0.0001)
+  expect_equal(
+    predict(res_xy, hpc[1:5, num_pred]),
+    predict(res_xy, hpc[1:5, sample(num_pred)])
+  )
 
   res_form <- fit(
     hpc_basic,

--- a/tests/testthat/test-glmnet-logistic.R
+++ b/tests/testthat/test-glmnet-logistic.R
@@ -78,6 +78,11 @@ test_that('glmnet prediction, one lambda', {
   uni_pred <- unname(uni_pred)
 
   expect_equal(uni_pred, predict(xy_fit, lending_club[1:7, num_pred])$.pred_class)
+  expect_equal(
+    predict(xy_fit, lending_club[1:7, num_pred]),
+    predict(xy_fit, lending_club[1:7, sample(num_pred)])
+  )
+
 
   res_form <- fit(
     logistic_reg(penalty = 0.1) %>% set_engine("glmnet"),

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -71,6 +71,10 @@ test_that('glmnet prediction, one lambda', {
   uni_pred <- unname(uni_pred)
 
   expect_equal(uni_pred, predict(xy_fit, hpc[rows, 1:4], type = "class")$.pred_class)
+  expect_equal(
+    predict(xy_fit, hpc[rows, 1:4], type = "class"),
+    predict(xy_fit, hpc[rows, c(3:1, 4)], type = "class")
+  )
 
   res_form <- fit(
     multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),


### PR DESCRIPTION
Related to tidymodels/parsnip#382

This PR adds tests to check that predictions for the `x`/`y` interface of glmnet are the same no matter what order the columns come in.