### PR TITLE
Add parallel tests for Windows back in

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -105,7 +105,7 @@ jobs:
         env:
           _R_CHECK_CRAN_INCOMING_: false
         run: |
-          devtools::install_local(force = TRUE)
+          remotes::install_local(force = TRUE)
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 

--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -104,7 +104,9 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: |
+          devtools::install_local(force = TRUE)
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
       - name: Show testthat output

--- a/tests/testthat/test-parallel-psock.R
+++ b/tests/testthat/test-parallel-psock.R
@@ -1,4 +1,3 @@
-library(extratests)
 library(testthat)
 library(discrim)
 library(tidymodels)
@@ -15,7 +14,6 @@ folds <- vfold_cv(two_class_dat)
 
 test_that('LDA parallel test', {
   skip_if(utils::packageVersion("discrim") <= "0.1.0.9000")
-  skip_on_os("windows")
 
   library(doParallel)
   cl <- makePSOCKcluster(2)

--- a/tests/testthat/test-parallel-seeds.R
+++ b/tests/testthat/test-parallel-seeds.R
@@ -1,5 +1,4 @@
 library(testthat)
-library(extratests)
 library(tidymodels)
 library(modeldata)
 library(doParallel)
@@ -17,7 +16,6 @@ folds <- vfold_cv(two_class_dat)
 
 test_that('parallel seeds', {
   skip_if(utils::packageVersion("tune") <= "0.1.1.9000")
-  skip_on_os("windows")
 
   library(doParallel)
   cl <- makePSOCKcluster(2)


### PR DESCRIPTION
This PR adds back in the tests for parallel processing on Windows that were removed in #10.