### PR TITLE
Add back in data descriptor test for Spark

### DIFF
--- a/tests/testthat/test-spark-data-descriptors.R
+++ b/tests/testthat/test-spark-data-descriptors.R
@@ -34,7 +34,6 @@ class_tab <- table(hpc$class, dnn = NULL)
 test_that("spark descriptor", {
 
   skip_if_not_installed("sparklyr")
-  skip_on_os("linux")
 
   library(sparklyr)
   library(dplyr)


### PR DESCRIPTION
This PR adds back in the test for data descriptors on Spark removed in #10.

This will currently fail on Ubuntu because of backticks in the abort in parsnip. It comes from here:

```
> parsnip:::get_descr_form(compounds ~ class, data = hpc_descr)
$.cols
function () 
all_preds
<bytecode: 0x7fc264a0ddc8>
<environment: 0x7fc2828b4868>

$.preds
function () 
length(f_term_labels)
<bytecode: 0x7fc264a0dc78>
<environment: 0x7fc2828b4868>

$.obs
function () 
obs
<bytecode: 0x7fc264a13aa8>
<environment: 0x7fc2828b4868>

$.lvls
function () 
y_vals
<bytecode: 0x7fc264a13958>
<environment: 0x7fc2828b4868>

$.facts
function () 
factor_pred
<bytecode: 0x7fc264a13808>
<environment: 0x7fc2828b4868>

$.dat
function () 
abort("Descriptor `.dat()` not defined for Spark.")
<bytecode: 0x7fc264a134f8>
<environment: 0x7fc2828b4868>

$.x
function () 
abort("Descriptor `.x()` not defined for Spark.")
<bytecode: 0x7fc264a136b8>
<environment: 0x7fc2828b4868>

$.y
function () 
abort("Descriptor `.y()` not defined for Spark.")
<bytecode: 0x7fc264a135d8>
<environment: 0x7fc2828b4868>
```

And it results in this function erroring:

`sparklyr:::dbi_ensure_no_backtick(x)`

This is fine for me locally on MacOS.