### PR TITLE
Add tests for composition support

### DIFF
--- a/.github/workflows/CRAN-R-CMD-check.yaml
+++ b/.github/workflows/CRAN-R-CMD-check.yaml
@@ -100,7 +100,7 @@ jobs:
           path: check
 
       - name: Notify slack fail
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -117,7 +117,7 @@ jobs:
           path: check
 
       - name: Notify slack fail
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/spark-R-CMD-check.yaml
+++ b/.github/workflows/spark-R-CMD-check.yaml
@@ -96,7 +96,7 @@ jobs:
           path: check
 
       - name: Notify slack fail
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Suggests:
     rlang,
     discrim,
     themis,
+    hardhat,
     doParallel,
     parallel,
     poissonreg,

--- a/tests/testthat/test-sparse-glmnet.R
+++ b/tests/testthat/test-sparse-glmnet.R
@@ -1,0 +1,115 @@
+library(testthat)
+library(tidymodels)
+library(hardhat)
+data(mlc_churn, package = "modeldata")
+
+set.seed(123)
+mlc_folds <- vfold_cv(mlc_churn, v = 5)
+
+## -----------------------------------------------------------------------------
+
+parsnip_mod <-
+  logistic_reg(penalty = .1) %>%
+  set_engine("glmnet")
+
+wf <-
+  workflow() %>%
+  add_model(parsnip_mod)
+
+rec <-
+  recipe(churn ~ number_vmail_messages + number_customer_service_calls + international_plan,
+         data = mlc_churn)
+
+sparse_bp <- default_recipe_blueprint(composition = "dgCMatrix")
+matrix_bp <- default_recipe_blueprint(composition = "matrix")
+
+## -----------------------------------------------------------------------------
+
+test_that('sparse composition errors', {
+
+  expect_error(
+    mold(rec, mlc_churn, blueprint = sparse_bp),
+    "are not numeric"
+  )
+
+})
+
+test_that('sparse composition works', {
+
+  rec <- rec %>% step_dummy(international_plan)
+
+  expect_error(
+    processed <- mold(rec, mlc_churn, blueprint = sparse_bp),
+    NA
+  )
+  expect_s4_class(processed$predictors, "dgCMatrix")
+
+  forged <- forge(mlc_churn, blueprint = processed$blueprint)$predictors
+  expect_s4_class(forged, "dgCMatrix")
+
+
+  expect_error(
+    wf_pre <-
+      wf %>%
+      add_recipe(rec, blueprint = sparse_bp) %>%
+      .fit_pre(data = mlc_churn),
+    NA
+  )
+  expect_s4_class(wf_pre$pre$mold$predictors, "dgCMatrix")
+
+  expect_error(
+    .fit_model(wf_pre, control = control_workflow()),
+    NA
+  )
+
+  expect_error(
+    wf %>%
+      add_recipe(rec, blueprint = sparse_bp) %>%
+      fit_resamples(mlc_folds),
+    NA
+  )
+
+})
+
+test_that('matrix composition works', {
+
+  rec <- rec %>% step_dummy(international_plan)
+
+  expect_error(
+    processed <- mold(rec, mlc_churn, blueprint = matrix_bp),
+    NA
+  )
+  expect_type(processed$predictors, "double")
+  expect_equal(dim(processed$predictors), c(5000, 3))
+
+  forged <- forge(mlc_churn, blueprint = processed$blueprint)$predictors
+  expect_type(forged, "double")
+  expect_equal(dim(forged), c(5000, 3))
+
+
+  expect_error(
+    wf_pre <-
+      wf %>%
+      add_recipe(rec, blueprint = matrix_bp) %>%
+      .fit_pre(data = mlc_churn),
+    NA
+  )
+  expect_type(wf_pre$pre$mold$predictors, "double")
+  expect_equal(dim(wf_pre$pre$mold$predictors), c(5000, 3))
+
+
+  expect_error(
+    .fit_model(wf_pre, control = control_workflow()),
+    NA
+  )
+
+  expect_error(
+    wf %>%
+      add_recipe(rec, blueprint = matrix_bp) %>%
+      fit_resamples(mlc_folds),
+    NA
+  )
+
+})
+
+


### PR DESCRIPTION
Closes tidymodels/tidymodels#42

This PR adds tests for the sparse and matrix `composition` in recipes through fitting and tuning.