### PR TITLE
Test predicting single observation for glmnet models

### DIFF
--- a/tests/testthat/test-glmnet-linear.R
+++ b/tests/testthat/test-glmnet-linear.R
@@ -69,6 +69,7 @@ test_that('glmnet prediction, single lambda', {
 
   skip_if_not_installed("glmnet")
   skip_if(run_glmnet)
+  skip_if(utils::packageVersion("parsnip") <= "0.1.5")
 
   res_xy <- fit_xy(
     hpc_basic,

--- a/tests/testthat/test-glmnet-linear.R
+++ b/tests/testthat/test-glmnet-linear.R
@@ -84,6 +84,7 @@ test_that('glmnet prediction, single lambda', {
                 198.126819755653)
 
   expect_equal(uni_pred, predict(res_xy, hpc[1:5, num_pred])$.pred, tolerance = 0.0001)
+  expect_equal(uni_pred[3], predict(res_xy, hpc[3, num_pred])$.pred, tolerance = 0.0001)
   expect_equal(
     predict(res_xy, hpc[1:5, num_pred]),
     predict(res_xy, hpc[1:5, sample(num_pred)])

--- a/tests/testthat/test-glmnet-logistic.R
+++ b/tests/testthat/test-glmnet-logistic.R
@@ -57,6 +57,7 @@ test_that('glmnet prediction, one lambda', {
 
   skip_if_not_installed("glmnet")
   skip_if(run_glmnet)
+  skip_if(utils::packageVersion("parsnip") <= "0.1.5")
 
   xy_fit <- fit_xy(
     logistic_reg(penalty = 0.1) %>% set_engine("glmnet"),

--- a/tests/testthat/test-glmnet-logistic.R
+++ b/tests/testthat/test-glmnet-logistic.R
@@ -74,6 +74,7 @@ test_that('glmnet prediction, one lambda', {
   uni_pred <- unname(uni_pred)
 
   expect_equal(uni_pred, predict(xy_fit, lending_club[1:7, num_pred])$.pred_class)
+  expect_equal(uni_pred[2], predict(xy_fit, lending_club[2, num_pred])$.pred_class)
   expect_equal(
     predict(xy_fit, lending_club[1:7, num_pred]),
     predict(xy_fit, lending_club[1:7, sample(num_pred)])

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -51,6 +51,7 @@ test_that('glmnet prediction, one lambda', {
 
   skip_if_not_installed("glmnet")
   skip_if(run_glmnet)
+  skip_if(utils::packageVersion("parsnip") <= "0.1.5")
 
   xy_fit <- fit_xy(
     multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -67,6 +67,7 @@ test_that('glmnet prediction, one lambda', {
   uni_pred <- unname(uni_pred)
 
   expect_equal(uni_pred, predict(xy_fit, hpc[rows, 1:4], type = "class")$.pred_class)
+  expect_error(predict(xy_fit, hpc[3, 1:4], type = "class")$.pred_class, NA)
   expect_equal(
     predict(xy_fit, hpc[rows, 1:4], type = "class"),
     predict(xy_fit, hpc[rows, c(3:1, 4)], type = "class")


### PR DESCRIPTION
Related to tidymodels/parsnip#395

This PR tests the single observation case for glmnet models. It will fail until the parsnip PR is merged in.