### PR TITLE
Create separate package caches for each sets of tests

### DIFF
--- a/.github/workflows/CRAN-R-CMD-check.yaml
+++ b/.github/workflows/CRAN-R-CMD-check.yaml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-
+          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-CRAN-1-${{ hashFiles('.github/r-depends.rds') }}
+          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-CRAN-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -51,8 +51,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-
+          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-GH-1-${{ hashFiles('.github/r-depends.rds') }}
+          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-GH-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/spark-R-CMD-check.yaml
+++ b/.github/workflows/spark-R-CMD-check.yaml
@@ -48,8 +48,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-2-
+          key: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-spark-1-${{ hashFiles('.github/r-depends.rds') }}
+          restore-keys: ${{ runner.os }}-${{ steps.install-r.outputs.installed-r-version }}-spark-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
[This failure](https://github.com/tidymodels/extratests/actions/runs/834238237) indicates that there are devel versions of packages in the CRAN workflow 😱 and Jim says that the cache seem to be shared. This PR creates separate package caches for each of the CRAN, GH, and Spark sets of tests.