### PR TITLE
bump stacks version

### DIFF
--- a/tests/testthat/test-stacks-columns.R
+++ b/tests/testthat/test-stacks-columns.R
@@ -15,7 +15,7 @@ library(dplyr)
 
 test_that("stacks can accommodate outcome levels that are not valid colnames", {
   # skip on pre-0.2.2
-  skip_if(utils::packageVersion("stacks") < "0.2.1.9000")
+  skip_if(utils::packageVersion("stacks") < "0.2.2.9001")
 
   data("penguins")
 


### PR DESCRIPTION
Addresses the current failing tests for stacks—more info on tidymodels/stacks#99. :)