### PR TITLE
install devel parsnip last

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -57,7 +57,6 @@ jobs:
           try(pak::pkg_install("tidymodels/tidymodels"))
           try(pak::pkg_install("tidymodels/workflows"))
           try(pak::pkg_install("tidymodels/hardhat"))
-          try(pak::pkg_install("tidymodels/parsnip@feature/case-weights"))
           try(pak::pkg_install("tidymodels/dials"))
           try(pak::pkg_install("tidymodels/recipes@case-weights"))
           try(pak::pkg_install("tidymodels/tune"))
@@ -69,6 +68,7 @@ jobs:
           try(pak::pkg_install("tidymodels/discrim"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/spatialsample"))
+          try(pak::pkg_install("tidymodels/parsnip@feature/case-weights"))
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
At first, the current Action installs the correct parsnip version 284252b with case weights: https://github.com/tidymodels/extratests/runs/6210633506?check_suite_focus=true#step:6:69

but then it’s "updated" to the main branch version 80ebaa8 later on: https://github.com/tidymodels/extratests/runs/6210633506?check_suite_focus=true#step:6:267

I was able to reproduce the errors in those above checks by installing parsnip from the github main branch and leaving all other package versions as instructed in the current draft of the case weights blog post. We'll see if this does the trick to fix it!