### PR TITLE
no more case weights branch for recipes

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -63,7 +63,7 @@ jobs:
           try(pak::pkg_install("tidymodels/workflows"))
           try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/dials"))
-          try(pak::pkg_install("tidymodels/recipes@case-weights"))
+          try(pak::pkg_install("tidymodels/recipes"))
           try(pak::pkg_install("tidymodels/tune"))
           try(pak::pkg_install("tidymodels/stacks"))
           try(pak::pkg_install("tidymodels/rsample"))


### PR DESCRIPTION
Since the [case weights branch of recipes](https://github.com/tidymodels/recipes/pull/835) was merged, it can no longer be installed and it rolls back to the CRAN version of recipes.