### PR TITLE
use main pkg refs in GH check

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -74,7 +74,7 @@ jobs:
           try(pak::pkg_install("tidymodels/discrim"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/spatialsample"))
-          try(pak::pkg_install("tidymodels/parsnip@feature/case-weights"))
+          try(pak::pkg_install("tidymodels/parsnip"))
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Now that case weights branches have been merged, we can use the main refs in Remotes across all repos. :)

Should be the last of our repos needing to make this switch—related to https://github.com/tidymodels/tune/pull/507, https://github.com/tidymodels/workflows/pull/153, https://github.com/tidymodels/workflowsets/pull/86.