### PR TITLE
Add parsnip extensions packages to dev workflow

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -59,22 +59,22 @@ jobs:
 
       - name: Install devel versions
         run: |
-          try(pak::pkg_install("tidymodels/tidymodels"))
-          try(pak::pkg_install("tidymodels/workflows"))
-          try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/dials"))
-          try(pak::pkg_install("tidymodels/recipes"))
-          try(pak::pkg_install("tidymodels/tune"))
-          try(pak::pkg_install("tidymodels/stacks"))
-          try(pak::pkg_install("tidymodels/rsample"))
-          try(pak::pkg_install("tidymodels/yardstick"))
-          try(pak::pkg_install("tidymodels/modeldata"))
-          try(pak::pkg_install("tidymodels/themis"))
-          try(pak::pkg_install("tidymodels/poissonreg"))
           try(pak::pkg_install("tidymodels/discrim"))
-          try(pak::pkg_install("tidymodels/plsmod"))
-          try(pak::pkg_install("tidymodels/spatialsample"))
+          try(pak::pkg_install("tidymodels/hardhat"))
+          try(pak::pkg_install("tidymodels/modeldata"))
           try(pak::pkg_install("tidymodels/parsnip"))
+          try(pak::pkg_install("tidymodels/plsmod"))
+          try(pak::pkg_install("tidymodels/poissonreg"))
+          try(pak::pkg_install("tidymodels/recipes"))
+          try(pak::pkg_install("tidymodels/rsample"))
+          try(pak::pkg_install("tidymodels/spatialsample"))
+          try(pak::pkg_install("tidymodels/stacks"))
+          try(pak::pkg_install("tidymodels/themis"))
+          try(pak::pkg_install("tidymodels/tidymodels"))
+          try(pak::pkg_install("tidymodels/tune"))
+          try(pak::pkg_install("tidymodels/workflows"))
+          try(pak::pkg_install("tidymodels/yardstick"))
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
The parsnip extension packages will get checked in the case-weights tests, so they should be added to the list of devel versions that get installed for the GH-R-CMD-check workflow.