### PR TITLE
test stacks with several tuning methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Depends:
 Suggests: 
     baguette,
     bonsai,
+    BradleyTerry2,
     butcher,
     C50,
     censored,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Suggests:
     dplyr,
     earth,
     fastICA,
+    finetune,
     flexsurv,
     glmnet,
     hardhat,
@@ -56,6 +57,7 @@ Suggests:
     tidyr,
     tune,
     workflows,
+    workflowsets,
     xgboost,
     yardstick
 Remotes:

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -295,6 +295,17 @@ test_that("stacking with finetune works (win_loss)", {
       metrics = metric
     )
 
+  warning(paste0("Class of workflow_set: ", class(wf_set_win_loss)[[1]]))
+
+  for (i in seq_along(wf_set_win_loss$result)) {
+    warning(paste0("workflow ID:", wf_set_win_loss$wflow_id[i]))
+    warning(paste0(class(wf_set_win_loss$result[[i]]), collapse = ", "))
+    warning(paste0(colnames(wf_set_win_loss$result[[i]]$.notes[[1]]), " "))
+    warning(paste0(wf_set_win_loss$result[[i]]$.notes[[1]], " "))
+    warning(paste0(colnames(wf_set_win_loss$result[[i]]$.notes[[7]]), " "))
+    warning(paste0(wf_set_win_loss$result[[i]]$.notes[[7]], " "))
+  }
+
   warning(paste0(c("Candidates are fitted: ", purrr::map_lgl(wf_set_win_loss$result, inherits, "tune_results"))))
 
   data_st_win_loss <-

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -77,6 +77,8 @@ wf_set <-
 
 # tests ------------------------------------------------------------------
 test_that("stacking with grid search works", {
+  skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+
   wf_set_grid <-
     workflow_map(
       wf_set %>% option_add(control = control_stack_grid()),
@@ -118,6 +120,8 @@ test_that("stacking with grid search works", {
 })
 
 test_that("stacking with Bayesian tuning works", {
+  skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+
   wf_set_bayes <-
     workflow_map(
       wf_set %>% option_add(control = control_stack_bayes()),
@@ -159,6 +163,8 @@ test_that("stacking with Bayesian tuning works", {
 })
 
 test_that("stacking with finetune works (anova)", {
+  skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+
   wf_set_anova <-
     workflow_map(
       wf_set  %>% option_add(control = control_race(save_pred = TRUE, save_workflow = TRUE)),
@@ -219,6 +225,8 @@ test_that("stacking with finetune works (anova)", {
 })
 
 test_that("stacking with finetune works (sim_anneal)", {
+  skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+
   wf_set_sim_anneal <-
     workflow_map(
       wf_set  %>% option_add(control = control_sim_anneal(save_pred = TRUE, save_workflow = TRUE)),
@@ -269,6 +277,8 @@ test_that("stacking with finetune works (sim_anneal)", {
 
 
 test_that("stacking with finetune works (win_loss)", {
+  skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+
   wf_set_win_loss <-
     workflow_map(
       wf_set  %>% option_add(control = control_race(save_pred = TRUE, save_workflow = TRUE)),

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -230,6 +230,7 @@ test_that("stacking with finetune works (anova)", {
 
 test_that("stacking with finetune works (sim_anneal)", {
   skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
+  skip_if(utils::packageVersion("finetune") < "1.0.1.9001")
 
   wf_set_sim_anneal <-
     workflow_map(

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -295,18 +295,6 @@ test_that("stacking with finetune works (win_loss)", {
       metrics = metric
     )
 
-  warning(paste0("Class of workflow_set: ", class(wf_set_win_loss)[[1]]))
-
-  for (i in seq_along(wf_set_win_loss$result)) {
-    warning(paste0("workflow ID:", wf_set_win_loss$wflow_id[i]))
-    warning(paste0(class(wf_set_win_loss$result[[i]]), collapse = ", "))
-    if (inherits(wf_set_win_loss$result[[i]], "try-error")) {
-      warning(conditionMessage(attr(wf_set_win_loss$result[[i]], "condition")))
-    }
-  }
-
-  warning(paste0(c("Candidates are fitted: ", purrr::map_lgl(wf_set_win_loss$result, inherits, "tune_results"))))
-
   data_st_win_loss <-
     stacks() %>%
     add_candidates(wf_set_win_loss)

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -174,6 +174,10 @@ test_that("stacking with finetune works (anova)", {
       metrics = metric
     )
 
+  wf_set_anova <- wf_set_anova[
+    purrr::map(wf_set_anova$result, inherits, "tune_results") %>% unlist(),
+  ]
+
   data_st_anova <-
     stacks() %>%
     add_candidates(wf_set_anova)
@@ -236,10 +240,12 @@ test_that("stacking with finetune works (sim_anneal)", {
       metrics = metric
     )
 
+  wf_set_sim_anneal <- wf_set_sim_anneal[
+    purrr::map(wf_set_sim_anneal$result, inherits, "tune_results") %>% unlist(),
+  ]
+
   wf_set_preds <-
-    wf_set_sim_anneal[
-      purrr::map(wf_set_sim_anneal$result, inherits, "tune_results") %>% unlist(),
-    ] %>%
+    wf_set_sim_anneal %>%
     collect_metrics(summarize = FALSE) %>%
     group_by(wflow_id, .config) %>%
     count()
@@ -287,6 +293,10 @@ test_that("stacking with finetune works (win_loss)", {
       resamples = folds,
       metrics = metric
     )
+
+  wf_set_win_loss <- wf_set_win_loss[
+    purrr::map(wf_set_win_loss$result, inherits, "tune_results") %>% unlist(),
+  ]
 
   data_st_win_loss <-
     stacks() %>%

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -58,7 +58,7 @@ spec_svm <-
   set_mode("regression")
 
 spec_nn <-
-  mlp(hidden_units = tune(), penalty = tune(), epochs = tune()) %>%
+  mlp(penalty = tune()) %>%
   set_engine("nnet") %>%
   set_mode("regression")
 
@@ -295,19 +295,18 @@ test_that("stacking with finetune works (win_loss)", {
       metrics = metric
     )
 
+  warning(paste0(c("Candidates are fitted: ", purrr::map_lgl(wf_set_win_loss$result, inherits, "tune_results"))))
+
   data_st_win_loss <-
     stacks() %>%
     add_candidates(wf_set_win_loss)
 
   expect_true(inherits(data_st_win_loss, "tbl_df"))
 
-  warning(paste0(c("Data stack column names", colnames(data_st_win_loss)), sep = ", "))
-  warning(paste0(c("Data stack column map", purrr::flatten_chr(attr(data_st_win_loss, "cols_map"))), sep = ", "))
-
-  warning(paste0("All data stack names in map: ", all(
+  expect_true(all(
     colnames(data_st_win_loss)[2:length(data_st_win_loss)] %in%
     purrr::flatten_chr(attr(data_st_win_loss, "cols_map"))
-  )))
+  ))
 
   model_st_win_loss <-
     data_st_win_loss %>%

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -300,10 +300,9 @@ test_that("stacking with finetune works (win_loss)", {
   for (i in seq_along(wf_set_win_loss$result)) {
     warning(paste0("workflow ID:", wf_set_win_loss$wflow_id[i]))
     warning(paste0(class(wf_set_win_loss$result[[i]]), collapse = ", "))
-    warning(paste0(colnames(wf_set_win_loss$result[[i]]$.notes[[1]]), " "))
-    warning(paste0(wf_set_win_loss$result[[i]]$.notes[[1]], " "))
-    warning(paste0(colnames(wf_set_win_loss$result[[i]]$.notes[[7]]), " "))
-    warning(paste0(wf_set_win_loss$result[[i]]$.notes[[7]], " "))
+    if (inherits(wf_set_win_loss$result[[i]], "try-error")) {
+      warning(conditionMessage(attr(wf_set_win_loss$result[[i]], "condition")))
+    }
   }
 
   warning(paste0(c("Candidates are fitted: ", purrr::map_lgl(wf_set_win_loss$result, inherits, "tune_results"))))

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -58,7 +58,7 @@ spec_svm <-
   set_mode("regression")
 
 spec_nn <-
-  mlp(penalty = tune(), dropout = tune()) %>%
+  mlp(hidden_units = tune(), penalty = tune(), epochs = tune()) %>%
   set_engine("nnet") %>%
   set_mode("regression")
 
@@ -295,15 +295,19 @@ test_that("stacking with finetune works (win_loss)", {
       metrics = metric
     )
 
-  wf_set_win_loss <- wf_set_win_loss[
-    purrr::map(wf_set_win_loss$result, inherits, "tune_results") %>% unlist(),
-  ]
-
   data_st_win_loss <-
     stacks() %>%
     add_candidates(wf_set_win_loss)
 
   expect_true(inherits(data_st_win_loss, "tbl_df"))
+
+  warning(paste0(c("Data stack column names", colnames(data_st_win_loss)), sep = ", "))
+  warning(paste0(c("Data stack column map", purrr::flatten_chr(attr(data_st_win_loss, "cols_map"))), sep = ", "))
+
+  warning(paste0("All data stack names in map: ", all(
+    colnames(data_st_win_loss)[2:length(data_st_win_loss)] %in%
+    purrr::flatten_chr(attr(data_st_win_loss, "cols_map"))
+  )))
 
   model_st_win_loss <-
     data_st_win_loss %>%

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -1,0 +1,310 @@
+# load libraries ----------------------------------------------------------
+library(stacks)
+library(tune)
+library(finetune)
+library(rsample)
+library(parsnip)
+library(workflows)
+library(recipes)
+library(yardstick)
+library(workflowsets)
+library(modeldata)
+
+# data setup ------------------------------------------------------------
+data(ames)
+ames$Sale_Price <- log(ames$Sale_Price)
+
+set.seed(1)
+ames_split <- rsample::initial_split(ames)
+
+ames_train <- rsample::training(ames_split)
+
+ames_test  <- rsample::testing(ames_split)
+
+n_res <- 12
+
+folds <- rsample::bootstraps(ames_train, times = n_res)
+
+base_rec <-
+  recipe(Sale_Price ~ ., data = ames_train) %>%
+  step_impute_mode(all_nominal_predictors()) %>%
+  step_impute_mean(all_numeric_predictors()) %>%
+  step_other(all_nominal_predictors(), threshold = .1) %>%
+  step_dummy(all_nominal_predictors()) %>%
+  step_zv(all_predictors()) %>%
+  step_corr(all_numeric_predictors())
+
+metric <- yardstick::metric_set(yardstick::rmse)
+
+# model definitions ----------------------------------------------------------
+spec_lr <-
+  linear_reg(penalty = tune(), mixture = tune()) %>%
+  set_engine("glmnet") %>%
+  set_mode("regression")
+
+spec_bt <-
+  boost_tree(mtry = tune(), min_n = tune()) %>%
+  set_engine("xgboost") %>%
+  set_mode("regression")
+
+spec_dt <-
+  decision_tree(cost_complexity = tune(), tree_depth = tune()) %>%
+  set_engine("rpart") %>%
+  set_mode("regression")
+
+spec_svm <-
+  svm_linear(cost = tune(), margin = tune()) %>%
+  set_engine("LiblineaR") %>%
+  set_mode("regression")
+
+spec_nn <-
+  mlp(penalty = tune(), dropout = tune()) %>%
+  set_engine("nnet") %>%
+  set_mode("regression")
+
+spec_knn <-
+  nearest_neighbor(neighbors = tune(), weight_func = tune()) %>%
+  set_engine("kknn") %>%
+  set_mode("regression")
+
+wf_set <-
+  workflow_set(
+    preproc = list(rec = base_rec),
+    models = list(lr = spec_lr, bt = spec_bt, dt = spec_dt, svm = spec_svm,
+                  nn = spec_nn, knn = spec_knn),
+    cross = TRUE
+  )
+
+# tests ------------------------------------------------------------------
+test_that("stacking with grid search works", {
+  wf_set_grid <-
+    workflow_map(
+      wf_set %>% option_add(control = control_stack_grid()),
+      fn = "tune_grid",
+      seed = 1,
+      resamples = folds,
+      metrics = metric
+    )
+
+  data_st_grid <-
+    stacks() %>%
+    add_candidates(wf_set_grid)
+
+  expect_true(inherits(data_st_grid, "tbl_df"))
+
+  model_st_grid <-
+    data_st_grid %>%
+    blend_predictions() %>%
+    fit_members()
+
+  expect_true(inherits(model_st_grid, "model_stack"))
+
+  betas_grid <-
+    stacks:::.get_glmn_coefs(
+      model_st_grid$coefs$fit,
+      penalty = model_st_grid$penalty$penalty
+    ) %>%
+    rowwise() %>%
+    dplyr::filter(terms != "(Intercept)" && estimate != 0) %>%
+    ungroup()
+
+  expect_true(nrow(betas_grid) == length(model_st_grid$member_fits))
+  expect_true(all(betas_grid$terms %in% names(model_st_grid$member_fits)))
+
+  preds_grid <-
+    predict(model_st_grid, ames_test)
+
+  expect_true(inherits(preds_grid, "tbl_df"))
+})
+
+test_that("stacking with Bayesian tuning works", {
+  wf_set_bayes <-
+    workflow_map(
+      wf_set %>% option_add(control = control_stack_bayes()),
+      fn = "tune_bayes",
+      seed = 1,
+      resamples = folds,
+      metrics = metric
+    )
+
+  data_st_bayes <-
+    stacks() %>%
+    add_candidates(wf_set_bayes)
+
+  expect_true(inherits(data_st_bayes, "tbl_df"))
+
+  model_st_bayes <-
+    data_st_bayes %>%
+    blend_predictions() %>%
+    fit_members()
+
+  expect_true(inherits(model_st_bayes, "model_stack"))
+
+  betas_bayes <-
+    stacks:::.get_glmn_coefs(
+      model_st_bayes$coefs$fit,
+      penalty = model_st_bayes$penalty$penalty
+    ) %>%
+    rowwise() %>%
+    dplyr::filter(terms != "(Intercept)" && estimate != 0) %>%
+    ungroup()
+
+  expect_true(nrow(betas_bayes) == length(model_st_bayes$member_fits))
+  expect_true(all(betas_bayes$terms %in% names(model_st_bayes$member_fits)))
+
+  preds_bayes <-
+    predict(model_st_bayes, ames_test)
+
+  expect_true(inherits(preds_bayes, "tbl_df"))
+})
+
+test_that("stacking with finetune works (anova)", {
+  wf_set_anova <-
+    workflow_map(
+      wf_set  %>% option_add(control = control_race(save_pred = TRUE, save_workflow = TRUE)),
+      fn = "tune_race_anova",
+      seed = 1,
+      resamples = folds,
+      metrics = metric
+    )
+
+  data_st_anova <-
+    stacks() %>%
+    add_candidates(wf_set_anova)
+
+  expect_true(inherits(data_st_anova, "tbl_df"))
+
+  # ensure that only candidates with complete resamples were kept
+  raw_preds <- tune::collect_predictions(wf_set_anova, summarize = TRUE)
+
+  retain_configs <-
+    tune::collect_metrics(wf_set_anova, summarize = FALSE) %>%
+    dplyr::group_by(wflow_id, .config) %>%
+    dplyr::count() %>%
+    dplyr::ungroup() %>%
+    dplyr::filter(n == n_res) %>%
+    dplyr::select(wflow_id, .config) %>%
+    dplyr::rowwise() %>%
+    dplyr::mutate(
+      .config = gsub("Preprocessor|Model", "", .config),
+      col_name = paste(wflow_id, .config, sep = "_")
+    ) %>%
+    pull(col_name)
+
+  expect_true(all(colnames(data_st_anova)[2:length(data_st_anova)] %in% retain_configs))
+
+  model_st_anova <-
+    data_st_anova %>%
+    blend_predictions() %>%
+    fit_members()
+
+  expect_true(inherits(model_st_anova, "model_stack"))
+
+  betas_anova <-
+    stacks:::.get_glmn_coefs(
+      model_st_anova$coefs$fit,
+      penalty = model_st_anova$penalty$penalty
+    ) %>%
+    rowwise() %>%
+    dplyr::filter(terms != "(Intercept)" && estimate != 0) %>%
+    ungroup()
+
+  expect_true(nrow(betas_anova) == length(model_st_anova$member_fits))
+  expect_true(all(betas_anova$terms %in% names(model_st_anova$member_fits)))
+
+  preds_anova <-
+    predict(model_st_anova, ames_test)
+
+  expect_true(inherits(preds_anova, "tbl_df"))
+})
+
+test_that("stacking with finetune works (sim_anneal)", {
+  wf_set_sim_anneal <-
+    workflow_map(
+      wf_set  %>% option_add(control = control_sim_anneal(save_pred = TRUE, save_workflow = TRUE)),
+      fn = "tune_sim_anneal",
+      seed = 1,
+      resamples = folds,
+      metrics = metric
+    )
+
+  wf_set_preds <-
+    wf_set_sim_anneal[
+      purrr::map(wf_set_sim_anneal$result, inherits, "tune_results") %>% unlist(),
+    ] %>%
+    collect_metrics(summarize = FALSE) %>%
+    group_by(wflow_id, .config) %>%
+    count()
+
+  data_st_sim_anneal <-
+    stacks() %>%
+    add_candidates(wf_set_sim_anneal)
+
+  expect_true(inherits(data_st_sim_anneal, "tbl_df"))
+
+  model_st_sim_anneal <-
+    data_st_sim_anneal %>%
+    blend_predictions() %>%
+    fit_members()
+
+  expect_true(inherits(model_st_sim_anneal, "model_stack"))
+
+  betas_sim_anneal <-
+    stacks:::.get_glmn_coefs(
+      model_st_sim_anneal$coefs$fit,
+      penalty = model_st_sim_anneal$penalty$penalty
+    ) %>%
+    rowwise() %>%
+    dplyr::filter(terms != "(Intercept)" && estimate != 0) %>%
+    ungroup()
+
+  expect_true(nrow(betas_sim_anneal) == length(model_st_sim_anneal$member_fits))
+  expect_true(all(betas_sim_anneal$terms %in% names(model_st_sim_anneal$member_fits)))
+
+  preds_sim_anneal <-
+    predict(model_st_sim_anneal, ames_test)
+
+  expect_true(inherits(preds_sim_anneal, "tbl_df"))
+})
+
+
+test_that("stacking with finetune works (win_loss)", {
+  wf_set_win_loss <-
+    workflow_map(
+      wf_set  %>% option_add(control = control_race(save_pred = TRUE, save_workflow = TRUE)),
+      fn = "tune_race_win_loss",
+      seed = 1,
+      resamples = folds,
+      metrics = metric
+    )
+
+  data_st_win_loss <-
+    stacks() %>%
+    add_candidates(wf_set_win_loss)
+
+  expect_true(inherits(data_st_win_loss, "tbl_df"))
+
+  model_st_win_loss <-
+    data_st_win_loss %>%
+    blend_predictions() %>%
+    fit_members()
+
+  expect_true(inherits(model_st_win_loss, "model_stack"))
+
+  betas_win_loss <-
+    stacks:::.get_glmn_coefs(
+      model_st_win_loss$coefs$fit,
+      penalty = model_st_win_loss$penalty$penalty
+    ) %>%
+    rowwise() %>%
+    dplyr::filter(terms != "(Intercept)" && estimate != 0) %>%
+    ungroup()
+
+  expect_true(nrow(betas_win_loss) == length(model_st_win_loss$member_fits))
+  expect_true(all(betas_win_loss$terms %in% names(model_st_win_loss$member_fits)))
+
+  preds_win_loss <-
+    predict(model_st_win_loss, ames_test)
+
+  expect_true(inherits(preds_win_loss, "tbl_df"))
+})


### PR DESCRIPTION
`tune_race_anova()` would be the only tuning method that I'd imagine stacks might be especially sensitive to, so this adds tests to make sure that we correctly handle candidates based on whether they were completely resampled. Otherwise, this just makes sure we run through one worked example with `tune_grid()`, `tune_bayes()`, `tune_race_anova()`, `tune_sim_anneal()`, and `tune_win_loss()`, and check that the outputs have the classes we'd expect.