### PR TITLE
Update tests for `proportional_hazards()`

### DIFF
--- a/tests/testthat/_snaps/parsnip-case-weights.md
+++ b/tests/testthat/_snaps/parsnip-case-weights.md
@@ -125,7 +125,7 @@
 # proportional_hazards - glmnet censored case weights
 
     Code
-      wt_fit$fit$call
+      wt_fit$fit$fit$call
     Output
       glmnet::glmnet(x = data_obj$x, y = data_obj$y, family = "cox", 
           weights = weights, alpha = alpha, lambda = lambda)

--- a/tests/testthat/test-parsnip-case-weights.R
+++ b/tests/testthat/test-parsnip-case-weights.R
@@ -1030,8 +1030,8 @@ test_that('proportional_hazards - glmnet censored case weights', {
     set_mode("censored regression") %>%
     fit(Surv(time, event) ~ ., data = dat$full)
 
-  expect_snapshot(wt_fit$fit$call)
-  expect_unequal(coef(unwt_fit$fit), coef(wt_fit$fit))
+  expect_snapshot(wt_fit$fit$fit$call)
+  expect_unequal(coef(unwt_fit$fit$fit), coef(wt_fit$fit$fit))
 })
 
 

--- a/tests/testthat/test-parsnip-case-weights.R
+++ b/tests/testthat/test-parsnip-case-weights.R
@@ -1011,7 +1011,7 @@ test_that('proportional_hazards - survival censored case weights', {
 })
 
 test_that('proportional_hazards - glmnet censored case weights', {
-  skip_if_not_installed("censored", "0.1.0")
+  skip_if_not_installed("censored", "0.1.1.9001")
 
   dat <- make_cens_wts()
 


### PR DESCRIPTION
This PR changes the tests for `proportional_hazards()`, which look at the engine fit.

I changed where the engine fit is saved in the parsnip object in the dev version of censored, so the new tests run conditional on the dev version - so that the tests for the (current) CRAN version don't fall.