### PR TITLE
glmnet tests for `multinom_reg()`

### DIFF
--- a/tests/testthat/_snaps/glmnet-multinom.md
+++ b/tests/testthat/_snaps/glmnet-multinom.md
@@ -1,0 +1,7 @@
+# multi_predict() with default or single penalty value
+
+    Code
+      multi_predict(xy_fit, newdata = hpc[rows, 1:4], penalty = c(0.1, 0.5))
+    Error <rlang_error>
+      Did you mean to use `new_data` instead of `newdata`?
+

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -153,6 +153,24 @@ test_that("glmnet prediction: type raw", {
   expect_equal(nrow(xy_pred_1), 1)
 })
 
+test_that("formula interface can deal with missing values", {
+  skip_if_not_installed("glmnet")
+
+  data("hpc_data", package = "modeldata", envir = rlang::current_env())
+  hpc_data$compounds[1] <- NA
+
+  mr_spec <- multinom_reg(penalty = 0.1) %>% set_engine("glmnet")
+  f_fit <- fit(mr_spec, class ~ log(compounds) + input_fields, data = hpc_data)
+
+  f_pred <- predict(f_fit, hpc_data, type = "class")
+  expect_equal(nrow(f_pred), nrow(hpc_data))
+  expect_true(is.na(f_pred$.pred_class[1]))
+
+  f_pred <- predict(f_fit, hpc_data, type = "prob")
+  expect_equal(nrow(f_pred), nrow(hpc_data))
+  expect_true(all(is.na(f_pred[1,])))
+})
+
 test_that('glmnet probabilities, mulitiple lambda', {
 
   skip_if_not_installed("glmnet")

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -31,55 +31,24 @@ test_that("glmnet execution and model object", {
   expect_equal(f_fit$fit[-14], exp_fit[-14])
 })
 
-test_that('glmnet prediction, one lambda', {
+test_that("glmnet prediction: column order of `new_data` irrelevant", {
 
   skip_if_not_installed("glmnet")
 
   data("hpc_data", package = "modeldata", envir = rlang::current_env())
   hpc <- hpc_data[, c(2:5, 8)]
   rows <- c(1, 51, 101)
-  ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
 
   xy_fit <- fit_xy(
     multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),
-    control = ctrl,
     x = hpc[, 1:4],
     y = hpc$class
   )
 
-  uni_pred <-
-    predict(xy_fit$fit,
-            newx = as.matrix(hpc[rows, 1:4]),
-            s = xy_fit$spec$args$penalty, type = "class")
-  uni_pred <- factor(uni_pred[,1], levels = levels(hpc$class))
-  uni_pred <- unname(uni_pred)
-
-  expect_equal(uni_pred, predict(xy_fit, hpc[rows, 1:4], type = "class")$.pred_class)
-  expect_error(predict(xy_fit, hpc[3, 1:4], type = "class")$.pred_class, NA)
   expect_equal(
-    predict(xy_fit, hpc[rows, 1:4], type = "class"),
-    predict(xy_fit, hpc[rows, c(3:1, 4)], type = "class")
+    predict(xy_fit, hpc[rows, c(3:1, 4)], type = "class"),
+    predict(xy_fit, hpc[rows, 1:4], type = "class")
   )
-
-  res_form <- fit(
-    multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),
-    class ~ log(compounds) + input_fields,
-    data = hpc,
-    control = ctrl
-  )
-
-  form_mat <- model.matrix(class ~ log(compounds) + input_fields, data = hpc)
-  form_mat <- form_mat[rows, -1]
-
-  form_pred <-
-    predict(res_form$fit,
-            newx = form_mat,
-            s = res_form$spec$args$penalty,
-            type = "class")
-  form_pred <- factor(form_pred[,1], levels = levels(hpc$class))
-  expect_equal(form_pred, parsnip:::predict_class.model_fit(res_form, hpc[rows, c("compounds", "input_fields")]))
-  expect_equal(form_pred, predict(res_form, hpc[rows, c("compounds", "input_fields")], type = "class")$.pred_class)
-
 })
 
 test_that("glmnet prediction: type class", {

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -4,39 +4,6 @@ library(parsnip)
 R_version_too_small_for_glmnet <- utils::compareVersion('3.6.0', as.character(getRversion())) > 0
 skip_if(R_version_too_small_for_glmnet)
 
-test_that('glmnet execution', {
-
-  skip_if_not_installed("glmnet")
-
-  data("hpc_data", package = "modeldata", envir = rlang::current_env())
-  hpc <- hpc_data[, c(2:5, 8)]
-  ctrl <- control_parsnip(verbosity = 1, catch = FALSE)
-  caught_ctrl <- control_parsnip(verbosity = 1, catch = TRUE)
-
-  expect_error(
-    res <- fit_xy(
-      multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),
-      control = ctrl,
-      x = hpc[, 1:4],
-      y = hpc$class
-    ),
-    regexp = NA
-  )
-
-  expect_true(has_multi_predict(res))
-  expect_equal(multi_predict_args(res), "penalty")
-
-  expect_error(
-    glmnet_xy_catch <- fit_xy(
-      multinom_reg(penalty = 0.1) %>% set_engine("glmnet"),
-      x = hpc[, 2:5],
-      y = hpc$compounds,
-      control = caught_ctrl
-    )
-  )
-
-})
-
 test_that("glmnet execution and model object", {
   skip_if_not_installed("glmnet")
 

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -37,6 +37,33 @@ test_that('glmnet execution', {
 
 })
 
+test_that("glmnet execution and model object", {
+  skip_if_not_installed("glmnet")
+
+  data("hpc_data", package = "modeldata", envir = rlang::current_env())
+
+  hpc_x <- model.matrix(~ protocol + log(compounds) + input_fields,
+                        data = hpc_data)[, -1]
+  hpc_y <- hpc_data$class
+
+  exp_fit <- glmnet::glmnet(x = hpc_x, y = hpc_y, family = "multinomial")
+
+  mr_spec <- multinom_reg(penalty = 0.1) %>% set_engine("glmnet")
+  expect_error(
+    f_fit <- fit(mr_spec, class ~ protocol + log(compounds) + input_fields,
+                 data = hpc_data),
+    NA
+  )
+  expect_error(
+    xy_fit <- fit_xy(mr_spec, x = hpc_x, y = hpc_y),
+    NA
+  )
+
+  expect_equal(f_fit$fit, xy_fit$fit)
+  # removing call element
+  expect_equal(f_fit$fit[-14], exp_fit[-14])
+})
+
 test_that('glmnet prediction, one lambda', {
 
   skip_if_not_installed("glmnet")


### PR DESCRIPTION
Similar to https://github.com/tidymodels/extratests/pull/66 and #68

The best way to read the changes is probably again commit-by-commit.

The tests are similar in structure to those for `linear_reg()` and `logistic_reg()` and follow the ideas laid out in https://github.com/tidymodels/extratests/pull/66 and #68.