### PR TITLE
glmnet engines for `logistic_reg()` and `multinomial_reg()` respect the penalty from the spec

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -66,7 +66,7 @@ jobs:
           try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/modeldata"))
           try(pak::pkg_install("tidymodels/multilevelmod"))
-          try(pak::pkg_install("tidymodels/parsnip"))
+          try(pak::pkg_install("tidymodels/parsnip@glmnet-penalty-raw"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/poissonreg"))
           try(pak::pkg_install("tidymodels/recipes"))

--- a/tests/testthat/test-glmnet-logistic.R
+++ b/tests/testthat/test-glmnet-logistic.R
@@ -134,7 +134,7 @@ test_that("glmnet prediction: type raw", {
   lending_club_y <- lending_club$Class
 
   exp_fit <- glmnet::glmnet(x = lending_club_x, y = lending_club_y, family = "binomial")
-  exp_pred <- predict(exp_fit, lending_club_x)
+  exp_pred <- predict(exp_fit, lending_club_x, s = 0.123)
 
   lr_spec <- logistic_reg(penalty = 0.123) %>% set_engine("glmnet")
   f_fit <- fit(lr_spec, Class ~ log(funded_amnt) + int_rate + term,
@@ -144,7 +144,14 @@ test_that("glmnet prediction: type raw", {
   f_pred <- predict(f_fit, lending_club, type = "raw")
   xy_pred <- predict(xy_fit, lending_club_x, type = "raw")
   expect_equal(f_pred, xy_pred)
-  expect_equal(f_pred, exp_pred)
+  parsnip_version_without_bug_fix <-
+    utils::packageVersion("parsnip") < "1.0.3.9001"
+  if (parsnip_version_without_bug_fix) {
+    exp_pred <- predict(exp_fit, lending_club_x)
+    expect_equal(f_pred, exp_pred)
+  } else {
+    expect_equal(f_pred, exp_pred)
+  }
 
   # single prediction
   f_pred_1 <- predict(f_fit, lending_club[1, ], type = "raw")

--- a/tests/testthat/test-glmnet-logistic.R
+++ b/tests/testthat/test-glmnet-logistic.R
@@ -7,6 +7,7 @@ skip_if(R_version_too_small_for_glmnet)
 test_that("glmnet execution and model object", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term,
                                  data = lending_club)[, -1]
@@ -34,6 +35,7 @@ test_that("glmnet execution and model object", {
 test_that("glmnet prediction: type class", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term,
                                  data = lending_club)[, -1]
@@ -90,6 +92,7 @@ test_that("glmnet prediction: column order of `new_data` irrelevant", {
 test_that("glmnet prediction: type prob", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term, data = lending_club)[, -1]
   lending_club_y <- lending_club$Class
@@ -125,6 +128,7 @@ test_that("glmnet prediction: type prob", {
 test_that("glmnet prediction: type raw", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term, data = lending_club)[, -1]
   lending_club_y <- lending_club$Class
@@ -152,6 +156,7 @@ test_that("glmnet prediction: type raw", {
 test_that("formula interface can deal missing values", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club$funded_amnt[1] <- NA
 
@@ -168,6 +173,7 @@ test_that("formula interface can deal missing values", {
 test_that("glmnet multi_predict(): type class", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term, data = lending_club)[, -1]
   lending_club_y <- lending_club$Class
@@ -225,6 +231,7 @@ test_that("glmnet multi_predict(): type class", {
 test_that("glmnet multi_predict(): type prob", {
   skip_if_not_installed("glmnet")
 
+  data("lending_club", package = "modeldata", envir = rlang::current_env())
   lending_club <- lending_club[1:200, ]
   lending_club_x <- model.matrix(~ log(funded_amnt) + int_rate + term, data = lending_club)[, -1]
   lending_club_y <- lending_club$Class
@@ -234,7 +241,7 @@ test_that("glmnet multi_predict(): type prob", {
   exp_fit <- glmnet::glmnet(x = lending_club_x, y = lending_club_y, family = "binomial")
   exp_pred <- predict(exp_fit, lending_club_x, s = penalty_values, type = "response")
 
-  lr_spec <- logistic_reg(penalty = 0.01) %>% set_engine("glmnet")
+  lr_spec <- logistic_reg(penalty = 0.1) %>% set_engine("glmnet")
   f_fit <- fit(lr_spec, Class ~ log(funded_amnt) + int_rate + term,
                data = lending_club)
   xy_fit <- fit_xy(lr_spec, x = lending_club_x, y = lending_club_y)

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -145,6 +145,14 @@ test_that("glmnet prediction: type raw", {
   f_pred <- predict(f_fit, hpc_data, type = "raw")
   xy_pred <- predict(xy_fit, hpc_x, type = "raw")
   expect_equal(f_pred, xy_pred)
+  parsnip_version_without_bug_fix <-
+    utils::packageVersion("parsnip") < "1.0.3.9001"
+  if (parsnip_version_without_bug_fix) {
+    exp_pred <- predict(exp_fit, lending_club_x)
+    expect_equal(f_pred, exp_pred)
+  } else {
+    expect_equal(f_pred, exp_pred)
+  }
 
   # single prediction
   f_pred_1 <- predict(f_fit, hpc_data[1, ], type = "raw")

--- a/tests/testthat/test-glmnet-multinom.R
+++ b/tests/testthat/test-glmnet-multinom.R
@@ -148,7 +148,7 @@ test_that("glmnet prediction: type raw", {
   parsnip_version_without_bug_fix <-
     utils::packageVersion("parsnip") < "1.0.3.9001"
   if (parsnip_version_without_bug_fix) {
-    exp_pred <- predict(exp_fit, lending_club_x)
+    exp_pred <- predict(exp_fit, hpc_x)
     expect_equal(f_pred, exp_pred)
   } else {
     expect_equal(f_pred, exp_pred)


### PR DESCRIPTION
These are tests for https://github.com/tidymodels/parsnip/pull/863