### PR TITLE
Fix snapshot for `poisson_reg()`

### DIFF
--- a/tests/testthat/_snaps/parsnip-case-weights.md
+++ b/tests/testthat/_snaps/parsnip-case-weights.md
@@ -104,7 +104,7 @@
       print(wt_fit$fit$call)
     Output
       glmnet::glmnet(x = maybe_matrix(x), y = y, family = "poisson", 
-          weights = weights, path_values = ~10^(-4:-1))
+          weights = weights, lambda = ~10^(-4:-1))
 
 # poisson_reg - stan case weights
 

--- a/tests/testthat/test-parsnip-case-weights.R
+++ b/tests/testthat/test-parsnip-case-weights.R
@@ -927,6 +927,7 @@ test_that('poisson_reg - glmnet case weights', {
     fit(art ~ ., data = dat$full)
 
   expect_unequal(unwt_fit$fit$beta, wt_fit$fit$beta)
+  skip_if_not_installed("parsnip", "1.0.4.9000")
   expect_snapshot(print(wt_fit$fit$call))
 })
 


### PR DESCRIPTION
`poisson_reg()` now also safe-guards Ridge regression, so we do expect to see `lamda` there instead of `path_values`

https://github.com/tidymodels/parsnip/pull/880