### PR TITLE
Use a snapshot test to check the hardhat error

### DIFF
--- a/tests/testthat/_snaps/sparse-glmnet.md
+++ b/tests/testthat/_snaps/sparse-glmnet.md
@@ -1,0 +1,7 @@
+# sparse composition errors
+
+    Code
+      mold(rec, mlc_churn, blueprint = sparse_bp)
+    Error <rlang_error>
+      Columns (`international_plan`) are not numeric; cannot convert to matrix.
+

--- a/tests/testthat/_snaps/sparse-glmnet.md
+++ b/tests/testthat/_snaps/sparse-glmnet.md
@@ -3,5 +3,6 @@
     Code
       mold(rec, mlc_churn, blueprint = sparse_bp)
     Error <rlang_error>
-      Columns (`international_plan`) are not numeric; cannot convert to matrix.
+      `data` must only contain numeric columns.
+      i These columns aren't numeric: "international_plan".
 

--- a/tests/testthat/test-sparse-glmnet.R
+++ b/tests/testthat/test-sparse-glmnet.R
@@ -26,6 +26,8 @@ matrix_bp <- default_recipe_blueprint(composition = "matrix")
 ## -----------------------------------------------------------------------------
 
 test_that('sparse composition errors', {
+  skip_if_not_installed("hardhat", minimum_version = "1.2.0.9000")
+
   expect_snapshot(error = TRUE, {
     mold(rec, mlc_churn, blueprint = sparse_bp)
   })

--- a/tests/testthat/test-sparse-glmnet.R
+++ b/tests/testthat/test-sparse-glmnet.R
@@ -26,12 +26,9 @@ matrix_bp <- default_recipe_blueprint(composition = "matrix")
 ## -----------------------------------------------------------------------------
 
 test_that('sparse composition errors', {
-
-  expect_error(
-    mold(rec, mlc_churn, blueprint = sparse_bp),
-    "are not numeric"
-  )
-
+  expect_snapshot(error = TRUE, {
+    mold(rec, mlc_churn, blueprint = sparse_bp)
+  })
 })
 
 test_that('sparse composition works', {


### PR DESCRIPTION
We have checks for both CRAN versions and dev versions right? That means this will pass with CRAN hardhat and fail with dev hardhat until the dev version goes to CRAN, because I've improved on the error message here.

I don't think there is much we can do about that.