### PR TITLE
Refine tests for parsnip-survival-censoring-model

### DIFF
--- a/tests/testthat/_snaps/parsnip-survival-censoring-model.md
+++ b/tests/testthat/_snaps/parsnip-survival-censoring-model.md
@@ -38,7 +38,10 @@
       attr(,"class")
       [1] "censoring_model_reverse_km" "censoring_model"           
 
-# Handle unknown or missing censoring model
+# Handle unknown censoring model
 
-    no applicable method for 'predict' applied to an object of class "censoring_model"
+    Code
+      predict(alt_obj, time = 100)
+    Error <simpleError>
+      no applicable method for 'predict' applied to an object of class "censoring_model"
 

--- a/tests/testthat/_snaps/parsnip-survival-censoring-model.md
+++ b/tests/testthat/_snaps/parsnip-survival-censoring-model.md
@@ -22,12 +22,12 @@
       
       Right-censored response of a survival model
       
-      No.Observations: 167 
+      No.Observations: 228 
       
       Pattern:
                       Freq
-       event          120 
-       right.censored 47  
+       event          165 
+       right.censored 63  
       
       $label
       [1] "reverse_km"

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -4,8 +4,6 @@ skip_if_not_installed("prodlim")
 library(censored)
 
 test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
-  lung <- lung[complete.cases(lung), ]
-
   mod_fit <- survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
 
@@ -45,7 +43,6 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
 })
 
 test_that("print reverse Kaplan-Meier curves", {
-  lung <- lung[complete.cases(lung), ]
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
@@ -56,8 +53,6 @@ test_that("print reverse Kaplan-Meier curves", {
 })
 
 test_that("predict with reverse Kaplan-Meier curves", {
-  lung <- lung[complete.cases(lung), ]
-
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
@@ -95,8 +90,6 @@ test_that("predict with reverse Kaplan-Meier curves", {
 })
 
 test_that("Handle unknown or missing censoring model", {
-  lung <- lung[complete.cases(lung), ]
-
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -6,19 +6,20 @@ library(censored)
 test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
   lung <- lung[complete.cases(lung), ]
 
-  mod_fit <-
-    survival_reg() %>%
+  mod_fit <- survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
 
   expect_true(any(names(mod_fit) == "censor_probs"))
-  expect_true(
-    inherits(mod_fit$censor_probs,
-             c("censoring_model_reverse_km", "censoring_model")))
-  expect_equal(
-    names(mod_fit$censor_probs),
+
+  expect_s3_class(
+    mod_fit$censor_probs,
+    c("censoring_model_reverse_km", "censoring_model")
+  )
+  expect_named(
+    mod_fit$censor_probs,
     c("formula", "fit", "label", "required_pkgs")
   )
-  expect_true(inherits(mod_fit$censor_probs$fit, "prodlim"))
+  expect_s3_class(mod_fit$censor_probs$fit, "prodlim")
   expect_equal(
     mod_fit$censor_probs$formula,
     Surv(time, status) ~ age + sex,
@@ -29,7 +30,6 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
     Surv(time, status) ~ 1,
     ignore_formula_env = TRUE
   )
-
   expect_equal(mod_fit$censor_probs$label, "reverse_km")
   expect_equal(mod_fit$censor_probs$required_pkgs, "prodlim")
 

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -33,7 +33,6 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
   expect_equal(mod_fit$censor_probs$label, "reverse_km")
   expect_equal(mod_fit$censor_probs$required_pkgs, "prodlim")
 
-
   rev_km_fit <- as_tibble(mod_fit$censor_probs$fit[1:6])
   exp_rev_km_fit <- prodlim::prodlim(
     Surv(time, status) ~ 1,
@@ -42,11 +41,7 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
     type = "surv"
   )
   exp_rev_km_fit <- as_tibble(exp_rev_km_fit[1:6])
-
-  expect_equal(
-    exp_rev_km_fit,
-    rev_km_fit
-  )
+  expect_equal(rev_km_fit, exp_rev_km_fit)
 })
 
 test_that("print reverse Kaplan-Meier curves", {

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -10,17 +10,6 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
 
-  psnip_df <- as_tibble(mod_fit$censor_probs$fit[1:6])
-
-  prdlim <-
-    prodlim::prodlim(
-      Surv(time, status) ~ 1,
-      data = lung,
-      reverse = TRUE,
-      type = "surv"
-    )
-  prdlim_df <- as_tibble(prdlim[1:6])
-
   expect_true(any(names(mod_fit) == "censor_probs"))
   expect_true(
     inherits(mod_fit$censor_probs,
@@ -43,6 +32,18 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
 
   expect_equal(mod_fit$censor_probs$label, "reverse_km")
   expect_equal(mod_fit$censor_probs$required_pkgs, "prodlim")
+
+
+  psnip_df <- as_tibble(mod_fit$censor_probs$fit[1:6])
+
+  prdlim <- prodlim::prodlim(
+    Surv(time, status) ~ 1,
+    data = lung,
+    reverse = TRUE,
+    type = "surv"
+  )
+  prdlim_df <- as_tibble(prdlim[1:6])
+
   expect_equal(
     prdlim_df,
     psnip_df

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -58,35 +58,25 @@ test_that("predict with reverse Kaplan-Meier curves", {
     fit(Surv(time, status) ~ age + sex, data = lung)
 
   pred_times <- (7:10) * 100
-  parsnip_df_pred <- predict(mod_fit$censor_probs, time = pred_times)
-  parsnip_vec_pred <-
-    predict(mod_fit$censor_probs, time = pred_times, as_vector = TRUE)
-  pl_pred <-
-    predict(mod_fit$censor_probs$fit, times = pred_times, type = "surv")
+  exp_pred <- predict(mod_fit$censor_probs$fit, times = pred_times, type = "surv")
+  pred_df <- predict(mod_fit$censor_probs, time = pred_times)
 
-  expect_true(inherits(parsnip_df_pred, "tbl_df"))
-  expect_equal(names(parsnip_df_pred), ".prob_censored")
-  expect_equal(nrow(parsnip_df_pred), length(pred_times))
-  expect_equal(parsnip_df_pred[[1]], pl_pred)
-  expect_equal(parsnip_vec_pred, pl_pred)
-  expect_true(inherits(parsnip_vec_pred, "numeric"))
+  expect_s3_class(pred_df, "tbl_df")
+  expect_named(pred_df, ".prob_censored")
+  expect_equal(nrow(pred_df), length(pred_times))
+  expect_equal(pred_df[[1]], exp_pred)
 
-  miss_pred <-
-    predict(mod_fit$censor_probs,
-            time = c(NA_real_, pred_times),
-            as_vector = TRUE)
-  expect_equal(
-    length(miss_pred),
-    length(pred_times) + 1
-  )
-  expect_equal(
-    sum(is.na(miss_pred)),
-    1L
-  )
-  expect_equal(
-    which(is.na(miss_pred)),
-    1
-  )
+  pred_vec <- predict(mod_fit$censor_probs, time = pred_times,
+                      as_vector = TRUE)
+  expect_type(pred_vec, "double")
+  expect_equal(pred_vec, exp_pred)
+
+  pred_miss <- predict(mod_fit$censor_probs,
+                       time = c(NA_real_, pred_times),
+                       as_vector = TRUE)
+  expect_equal(length(pred_miss), length(pred_times) + 1)
+  expect_equal(sum(is.na(pred_miss)), 1L)
+  expect_equal(which(is.na(pred_miss)), 1)
 })
 
 test_that("Handle unknown or missing censoring model", {

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -10,9 +10,6 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
 
-  # For testing purposes
-  attr(mod_fit$censor_probs$formula, ".Environment") <- rlang::base_env()
-
   psnip_df <- as_tibble(mod_fit$censor_probs$fit[1:6])
 
   prdlim <-

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -34,19 +34,18 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
   expect_equal(mod_fit$censor_probs$required_pkgs, "prodlim")
 
 
-  psnip_df <- as_tibble(mod_fit$censor_probs$fit[1:6])
-
-  prdlim <- prodlim::prodlim(
+  rev_km_fit <- as_tibble(mod_fit$censor_probs$fit[1:6])
+  exp_rev_km_fit <- prodlim::prodlim(
     Surv(time, status) ~ 1,
     data = lung,
     reverse = TRUE,
     type = "surv"
   )
-  prdlim_df <- as_tibble(prdlim[1:6])
+  exp_rev_km_fit <- as_tibble(exp_rev_km_fit[1:6])
 
   expect_equal(
-    prdlim_df,
-    psnip_df
+    exp_rev_km_fit,
+    rev_km_fit
   )
 })
 

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -79,18 +79,19 @@ test_that("predict with reverse Kaplan-Meier curves", {
   expect_equal(which(is.na(pred_miss)), 1)
 })
 
-test_that("Handle unknown or missing censoring model", {
+test_that("Handle unknown censoring model", {
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
 
   alt_obj <- mod_fit$censor_probs
   class(alt_obj) <- "censoring_model"
+  expect_snapshot(error = TRUE, predict(alt_obj, time = 100))
+})
 
-  expect_snapshot_error( predict(alt_obj, time = test_times) )
-
+test_that("`reverse_km()` returns NULL for unrelated modes", {
   expect_equal(
-    parsnip:::reverse_km(linear_reg(), NULL),
+    parsnip:::reverse_km(linear_reg(), eval_env = NULL),
     list()
   )
 })

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -70,7 +70,14 @@ test_that("predict with reverse Kaplan-Meier curves", {
                       as_vector = TRUE)
   expect_type(pred_vec, "double")
   expect_equal(pred_vec, exp_pred)
+})
 
+test_that("predict can handle NA times", {
+  mod_fit <-
+    survival_reg() %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred_times <- (7:10) * 100
   pred_miss <- predict(mod_fit$censor_probs,
                        time = c(NA_real_, pred_times),
                        as_vector = TRUE)


### PR DESCRIPTION
This PR reworks the tests to

- use more specific expectations like `expect_s3_class()`
- groups setup and expectations closer together when they are in the same test_that() call
- splits expectations into more test_that() calls to make the description of the test more specific
- allows missing values in the test data so that we notice if that ever were not to work again and because having it in there typically signals that the function cannot deal with missing values