### PR TITLE
Refine tests on parsnip's censoring models

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -65,7 +65,7 @@ jobs:
           try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/modeldata"))
           try(pak::pkg_install("tidymodels/multilevelmod"))
-          try(pak::pkg_install("tidymodels/parsnip"))
+          try(pak::pkg_install("tidymodels/parsnip#966"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/poissonreg"))
           try(pak::pkg_install("tidymodels/recipes"))

--- a/tests/testthat/_snaps/parsnip-survival-censoring-model.md
+++ b/tests/testthat/_snaps/parsnip-survival-censoring-model.md
@@ -3,45 +3,12 @@
     Code
       mod_fit$censor_probs
     Output
-      $formula
-      Surv(time, status) ~ age + sex
-      <environment: base>
-      
-      $fit
-      
-      Call: prodlim::prodlim(formula = Surv(time, status) ~ 1, data = eval_env$data, 
-          reverse = TRUE, x = FALSE, type = "surv")
-      
-    Message <simpleMessage>
-      Kaplan-Meier estimator for the censoring time survival function
-    Output
-      
-    Message <simpleMessage>
-      No covariates
-    Output
-      
-      Right-censored response of a survival model
-      
-      No.Observations: 228 
-      
-      Pattern:
-                      Freq
-       event          165 
-       right.censored 63  
-      
-      $label
-      [1] "reverse_km"
-      
-      $required_pkgs
-      [1] "prodlim"
-      
-      attr(,"class")
-      [1] "censoring_model_reverse_km" "censoring_model"           
+      reverse_km model for predicting the probability of censoring
 
 # Handle unknown censoring model
 
     Code
       predict(alt_obj, time = 100)
-    Error <simpleError>
-      no applicable method for 'predict' applied to an object of class "censoring_model"
+    Error <rlang_error>
+      Don't know how to predict with a censoring model of type: reverse_km
 

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -72,7 +72,7 @@ test_that("predict with reverse Kaplan-Meier curves", {
   expect_equal(pred_vec, exp_pred)
 })
 
-test_that("predict can handle NA times", {
+test_that("predict() can handle NA times", {
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
@@ -84,6 +84,20 @@ test_that("predict can handle NA times", {
   expect_equal(length(pred_miss), length(pred_times) + 1)
   expect_equal(sum(is.na(pred_miss)), 1L)
   expect_equal(which(is.na(pred_miss)), 1)
+})
+
+test_that("predict() avoids zero probabilities", {
+  mod_fit <-
+    survival_reg() %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  time_with_prob_0 <- max(lung$time)
+  exp_pred <- predict(mod_fit$censor_probs$fit, times = time_with_prob_0, type = "surv")
+
+  pred <- predict(mod_fit$censor_probs, time = time_with_prob_0,
+                      as_vector = TRUE)
+  expect_gt(pred, 0)
+  expect_gt(pred, exp_pred)
 })
 
 test_that("Handle unknown censoring model", {

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -43,11 +43,10 @@ test_that("`reverse_km()`: fit reverse Kaplan-Meier curves", {
 })
 
 test_that("print reverse Kaplan-Meier curves", {
+  skip_if_not_installed("parsnip", minimum_version = "1.1.0.9002")
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)
-  # For testing purposes
-  attr(mod_fit$censor_probs$formula, ".Environment") <- rlang::base_env()
 
   expect_snapshot(mod_fit$censor_probs)
 })
@@ -101,6 +100,7 @@ test_that("predict() avoids zero probabilities", {
 })
 
 test_that("Handle unknown censoring model", {
+  skip_if_not_installed("parsnip", minimum_version = "1.1.0.9002")
   mod_fit <-
     survival_reg() %>%
     fit(Surv(time, status) ~ age + sex, data = lung)


### PR DESCRIPTION
With this PR the tests on the censoring model are hopefully in good shape! Things that came up:

- Two S3 methods were not exported in parsnip and it showed in the snapshots. That's now fixed (in https://github.com/tidymodels/parsnip/pull/966 and here).
- The predict() method modifies probabilities of 0 (so that the resulting weights are usable). That hadn't been tested yet, this PR adds a test for it.
- The `new_data` arg to `predict()` doesn't do anything atm, I've opened an issue to discuss if we should deprecate it: https://github.com/tidymodels/parsnip/issues/965