### PR TITLE
`.check_censor_model()` now errors for models without "censored regression" mode

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -65,7 +65,7 @@ jobs:
           try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/modeldata"))
           try(pak::pkg_install("tidymodels/multilevelmod"))
-          try(pak::pkg_install("tidymodels/parsnip"))
+          try(pak::pkg_install("tidymodels/parsnip#972"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/poissonreg"))
           try(pak::pkg_install("tidymodels/recipes"))

--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -65,7 +65,7 @@ jobs:
           try(pak::pkg_install("tidymodels/hardhat"))
           try(pak::pkg_install("tidymodels/modeldata"))
           try(pak::pkg_install("tidymodels/multilevelmod"))
-          try(pak::pkg_install("tidymodels/parsnip#972"))
+          try(pak::pkg_install("tidymodels/parsnip"))
           try(pak::pkg_install("tidymodels/plsmod"))
           try(pak::pkg_install("tidymodels/poissonreg"))
           try(pak::pkg_install("tidymodels/recipes"))

--- a/tests/testthat/_snaps/parsnip-survival-censoring-weights.md
+++ b/tests/testthat/_snaps/parsnip-survival-censoring-weights.md
@@ -15,13 +15,6 @@
 ---
 
     Code
-      .censoring_weights_graf(wrong_model, lung2)
-    Error <rlang_error>
-      The input should have a list column called `.pred`.
-
----
-
-    Code
       .censoring_weights_graf(cox_model, lung)
     Error <rlang_error>
       There should be a single column of class `Surv`
@@ -55,4 +48,11 @@
       1 <tibble [2 x 5]>   306 
       2 <tibble [2 x 5]>   455 
       3 <tibble [2 x 5]>  1010+
+
+# error for .censoring_weights_graf() from .check_censor_model()
+
+    Code
+      .censoring_weights_graf(wrong_model, mtcars)
+    Error <rlang_error>
+      The model needs to be for mode 'censored regression', not for mode 'regression'.
 

--- a/tests/testthat/test-parsnip-survival-censoring-weights.R
+++ b/tests/testthat/test-parsnip-survival-censoring-weights.R
@@ -91,9 +91,11 @@ test_that("error messages in context of .censoring_weights_graf()", {
 
   expect_snapshot(error = TRUE, .censoring_weights_graf(workflows::workflow()))
 
-  # trigger `.check_censor_model()`
-  wrong_model <- fit(linear_reg(), mpg ~ ., data = mtcars)
-  expect_snapshot(error = TRUE, .censoring_weights_graf(wrong_model, lung2)) # FIXME
+  # temporarily moved to its own test below to allow skipping of (only) this test
+  # based on dev version number
+  # # trigger `.check_censor_model()`
+  # wrong_model <- fit(linear_reg(), mpg ~ ., data = mtcars)
+  # expect_snapshot(error = TRUE, .censoring_weights_graf(wrong_model, mtcars))
 
   # trigger `.find_surv_col()`
   cox_model <- proportional_hazards() %>% fit(surv ~ ., data = lung2)
@@ -124,4 +126,11 @@ test_that("error messages in context of .censoring_weights_graf()", {
       cens_predictors = "shouldn't be using this anyway!"
     )
   })
+})
+
+test_that("error for .censoring_weights_graf() from .check_censor_model()", {
+  # temporarily its own test, see above
+  skip_if_not_installed("parsnip", minimum_version = "1.1.0.9003")
+  wrong_model <- fit(linear_reg(), mpg ~ ., data = mtcars)
+  expect_snapshot(error = TRUE, .censoring_weights_graf(wrong_model, mtcars))
 })


### PR DESCRIPTION
test update for https://github.com/tidymodels/parsnip/pull/972