### PR TITLE
Less noise

### DIFF
--- a/tests/testthat/_snaps/parsnip-model-formula.md
+++ b/tests/testthat/_snaps/parsnip-model-formula.md
@@ -1,4 +1,4 @@
-# error with model formula (workflow, no tune)
+# error without model formula (workflow, no tune)
 
     Code
       gam_fit <- gam_wflow %>% fit(mtcars)
@@ -7,7 +7,7 @@
       ! When working with generalized additive models, please supply the model specification to `workflows::add_model()` along with a `formula` argument.
       i See `?parsnip::model_formula()` to learn more.
 
-# error with model formula (workflow, with tune)
+# error without model formula (workflow, with tune)
 
     Code
       show_notes(gam_res)
@@ -18,7 +18,7 @@
       ! When working with generalized additive models, please supply the model specification to `workflows::add_model()` along with a `formula` argument.
       i See `?parsnip::model_formula()` to learn more.
 
-# error with model formula (no workflow, with tune)
+# error without model formula (no workflow, with tune)
 
     Code
       show_notes(gam_res)

--- a/tests/testthat/test-engine-parameters-c5.R
+++ b/tests/testthat/test-engine-parameters-c5.R
@@ -38,7 +38,8 @@ test_that('single tree Bayesian search', {
   expect_error(
     tree_search <-
       tree_mod %>%
-      tune_bayes(Class ~ ., resamples = folds, initial = 3, iter = 2),
+      tune_bayes(Class ~ ., resamples = folds, initial = 3, iter = 2) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(tree_search)), 10)
@@ -61,7 +62,8 @@ test_that('boosted tree Bayesian search', {
   expect_error(
     boost_search <-
       boost_mod %>%
-      tune_bayes(Class ~ ., resamples = folds, initial = 3, iter = 2),
+      tune_bayes(Class ~ ., resamples = folds, initial = 3, iter = 2) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(boost_search)), 10)

--- a/tests/testthat/test-engine-parameters-earth.R
+++ b/tests/testthat/test-engine-parameters-earth.R
@@ -29,7 +29,8 @@ test_that('Bayes search', {
   expect_error(
     mars_search <-
       mars_mod %>%
-      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2),
+      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(mars_search)), 10)

--- a/tests/testthat/test-engine-parameters-randomForest.R
+++ b/tests/testthat/test-engine-parameters-randomForest.R
@@ -18,7 +18,8 @@ test_that('grid search', {
   expect_error(
     rf_tune <-
       rf_mod %>%
-      tune_grid(mpg ~ ., resamples = rs, grid = 4),
+      tune_grid(mpg ~ ., resamples = rs, grid = 4) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(rf_tune)), 8)
@@ -32,7 +33,8 @@ test_that('Bayes search', {
   expect_error(
     rf_search <-
       rf_mod %>%
-      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2),
+      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(rf_search)), 10)

--- a/tests/testthat/test-engine-parameters-ranger.R
+++ b/tests/testthat/test-engine-parameters-ranger.R
@@ -19,7 +19,8 @@ test_that('grid search', {
   expect_error(
     rf_tune <-
       rf_mod %>%
-      tune_grid(mpg ~ ., resamples = rs, grid = 4),
+      tune_grid(mpg ~ ., resamples = rs, grid = 4) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(rf_tune)), 8)
@@ -33,7 +34,8 @@ test_that('Bayes search', {
   expect_error(
     rf_search <-
       rf_mod %>%
-      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2),
+      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2) %>%
+      suppressMessages(),
     regex = NA
   )
   expect_equal(nrow(collect_metrics(rf_search)), 10)

--- a/tests/testthat/test-parsnip-model-formula.R
+++ b/tests/testthat/test-parsnip-model-formula.R
@@ -1,5 +1,5 @@
 test_that('error without model formula (workflow, no tune)', {
-  skip_if_not_installed("parsnip", min_version = "1.1.1.9001")
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9001")
 
   library(parsnip)
   library(workflows)
@@ -15,7 +15,7 @@ test_that('error without model formula (workflow, no tune)', {
 })
 
 test_that('error without model formula (workflow, with tune)', {
-  skip_if_not_installed("parsnip", min_version = "1.1.1.9001")
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9001")
 
   library(parsnip)
   library(workflows)
@@ -28,13 +28,14 @@ test_that('error without model formula (workflow, with tune)', {
 
   expect_warning(
     gam_res <- gam_wflow %>% fit_resamples(bootstraps(mtcars))
-  )
+  ) %>%
+    suppressMessages()
 
   expect_snapshot(show_notes(gam_res))
 })
 
 test_that('error without model formula (no workflow, with tune)', {
-  skip_if_not_installed("parsnip", min_version = "1.1.1.9001")
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9001")
 
   library(parsnip)
   library(tune)
@@ -44,7 +45,8 @@ test_that('error without model formula (no workflow, with tune)', {
 
   expect_warning(
     gam_res <- gam_spec %>% fit_resamples(mpg ~ ., bootstraps(mtcars))
-  )
+  ) %>%
+    suppressMessages()
 
   expect_snapshot(show_notes(gam_res))
 })

--- a/tests/testthat/test-stacks-columns.R
+++ b/tests/testthat/test-stacks-columns.R
@@ -43,8 +43,10 @@ test_that("stacks can accommodate outcome levels that are not valid colnames", {
   expect_true(".pred_Adelie.1_tuned_1_1" %in% colnames(data_st))
 
   # glmnet will likely present warnings
-  blended <- data_st %>%
+  suppressMessages(
+    blended <- data_st %>%
     blend_predictions()
+  )
 
   # ...though model fitting should work as expected
   expect_silent(

--- a/tests/testthat/test-stacks-tuning.R
+++ b/tests/testthat/test-stacks-tuning.R
@@ -86,7 +86,8 @@ test_that("stacking with grid search works", {
       seed = 1,
       resamples = folds,
       metrics = metric
-    )
+    ) %>%
+    suppressMessages()
 
   data_st_grid <-
     stacks() %>%
@@ -129,11 +130,13 @@ test_that("stacking with Bayesian tuning works", {
       seed = 1,
       resamples = folds,
       metrics = metric
-    )
+    ) %>%
+    suppressMessages()
 
   data_st_bayes <-
     stacks() %>%
-    add_candidates(wf_set_bayes)
+    add_candidates(wf_set_bayes) %>%
+    suppressMessages()
 
   expect_true(inherits(data_st_bayes, "tbl_df"))
 
@@ -234,7 +237,14 @@ test_that("stacking with finetune works (sim_anneal)", {
 
   wf_set_sim_anneal <-
     workflow_map(
-      wf_set  %>% option_add(control = control_sim_anneal(save_pred = TRUE, save_workflow = TRUE)),
+      wf_set  %>%
+        option_add(
+          control = control_sim_anneal(
+            save_pred = TRUE,
+            save_workflow = TRUE,
+            verbose_iter = FALSE
+          )
+        ),
       fn = "tune_sim_anneal",
       seed = 1,
       resamples = folds,
@@ -282,7 +292,6 @@ test_that("stacking with finetune works (sim_anneal)", {
   expect_true(inherits(preds_sim_anneal, "tbl_df"))
 })
 
-
 test_that("stacking with finetune works (win_loss)", {
   skip_if(utils::packageVersion("stacks") < "1.0.0.9000")
 
@@ -293,7 +302,8 @@ test_that("stacking with finetune works (win_loss)", {
       seed = 1,
       resamples = folds,
       metrics = metric
-    )
+    ) %>%
+    suppressMessages()
 
   data_st_win_loss <-
     stacks() %>%

--- a/tests/testthat/test-stan-linear.R
+++ b/tests/testthat/test-stan-linear.R
@@ -1,6 +1,5 @@
 library(testthat)
 library(parsnip)
-library(rlang)
 library(modeldata)
 
 ## -----------------------------------------------------------------------------

--- a/tests/testthat/test-stan-logistic.R
+++ b/tests/testthat/test-stan-logistic.R
@@ -1,6 +1,5 @@
 library(testthat)
 library(parsnip)
-library(rlang)
 library(tibble)
 library(modeldata)
 

--- a/tests/testthat/test-stan-poisson.R
+++ b/tests/testthat/test-stan-poisson.R
@@ -1,7 +1,6 @@
 
 ## -----------------------------------------------------------------------------
 
-library(rlang)
 library(poissonreg)
 library(tidyr)
 
@@ -21,10 +20,6 @@ glmn_spec <- poisson_reg(penalty = .01, mixture = .3) %>% set_engine("glmnet")
 stan_spec <- poisson_reg() %>% set_engine("stan", refresh = 0)
 hurdle_spec <- poisson_reg() %>% set_engine("hurdle")
 zeroinfl_spec <- poisson_reg() %>% set_engine("zeroinfl")
-
-new_empty_quosure <- function(expr) {
-  new_quosure(expr, env = empty_env())
-}
 
 # ------------------------------------------------------------------------------
 
@@ -142,6 +137,3 @@ test_that('stan intervals', {
                tolerance = 1e-2,
                ignore_attr = TRUE)
 })
-
-
-

--- a/tests/testthat/test-tune_bayes.R
+++ b/tests/testthat/test-tune_bayes.R
@@ -34,7 +34,8 @@ test_that('tune recipe and model, which has_unknowns', {
   )
   folds <- vfold_cv(mtcars)
   res <- tune_bayes(wflow, resamples = folds, param_info = pset,
-                    initial = iter1, iter = iter2)
+                    initial = iter1, iter = iter2) %>%
+    suppressMessages()
   expect_equal(unique(res$id), folds$id)
   expect_equal(
     colnames(res$.metrics[[1]]),


### PR DESCRIPTION
This is a first pass at #124 

This PR wraps  `suppressMessages()` around several calls to `tune_bayes()` and friends in cases where we don't do anything with the messages anyway. 

Also in this PR: removing some `library(rlang)` calls that are not needed anymore and resulted in a couple of lines of 
> The following object is masked from 