### PR TITLE
Improve test survival workflows

### DIFF
--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -3,7 +3,7 @@ skip_if_not_installed("parsnip", minimum_version = "1.1.0.9003")
 skip_if_not_installed("tune", minimum_version = "1.1.1.9001")
 
 library(tidymodels)
-library(censored)
+suppressPackageStartupMessages(library(censored))
 
 test_that("can `fit()` a censored workflow with a formula", {
   lung <- lung |>

--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -104,7 +104,7 @@ test_that("can `predict()` a censored workflow with a formula", {
   )
 })
 
-test_that("can `predict()` a censored workflow with a recipe", {
+test_that("can `predict()` a censored workflow with variables", {
   lung <- lung |>
     tidyr::drop_na() |>
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")

--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -6,8 +6,8 @@ library(tidymodels)
 suppressPackageStartupMessages(library(censored))
 
 test_that("can `fit()` a censored workflow with a formula", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
@@ -27,8 +27,8 @@ test_that("can `fit()` a censored workflow with a formula", {
 })
 
 test_that("can `fit()` a censored workflow with a model formula", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   model_formula <- surv ~ . - sex + strata(sex)
@@ -52,8 +52,8 @@ test_that("can `fit()` a censored workflow with a model formula", {
 })
 
 test_that("can `fit()` a censored workflow with variables", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
@@ -73,8 +73,8 @@ test_that("can `fit()` a censored workflow with variables", {
 })
 
 test_that("can `fit()` a censored workflow with a recipe", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   rec <- recipes::recipe(surv ~ ., lung)
@@ -96,8 +96,8 @@ test_that("can `fit()` a censored workflow with a recipe", {
 })
 
 test_that("can `predict()` a censored workflow with a formula", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
@@ -130,8 +130,8 @@ test_that("can `predict()` a censored workflow with a formula", {
 })
 
 test_that("can `predict()` a censored workflow with a model formula", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   model_formula <- surv ~ . - sex + strata(sex)
@@ -166,8 +166,8 @@ test_that("can `predict()` a censored workflow with a model formula", {
 })
 
 test_that("can `predict()` a censored workflow with variables", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
@@ -200,8 +200,8 @@ test_that("can `predict()` a censored workflow with variables", {
 })
 
 test_that("can `predict()` a censored workflow with a recipe", {
-  lung <- lung |>
-    tidyr::drop_na() |>
+  lung <- lung %>%
+    tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
   rec <- recipes::recipe(surv ~ ., lung)


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/extratests/issues/111.

With this PR, we are now testing a `proportional_hazards()` model in a workflow where we

- use a formula with `add_formula()`
- use a model formula passed to `add_model()` this formula contains `strata()`
- use variables with `add_variables()`
- use a recipe with `add_recipe()`

We are testing that we 

- can use `fit()`
- can use `predict()`
    - with `type = "time"` (default)
    - with `type = "survival"`