### PR TITLE
Follow-up to #131

### DIFF
--- a/tests/testthat/test-parsnip-survival-censoring-weights.R
+++ b/tests/testthat/test-parsnip-survival-censoring-weights.R
@@ -135,19 +135,13 @@ test_that("error for .censoring_weights_graf() from .check_censor_model()", {
   expect_snapshot(error = TRUE, .censoring_weights_graf(wrong_model, mtcars))
 })
 
-
 test_that("no names in weight values", {
   # See tidymodels/parsnip#1023 tidymodels/parsnip#1024
   skip_if_not_installed("parsnip", minimum_version = "1.1.1.9002")
 
-  surv_obj <-
-    structure(
-      c(9, 13, 13, 18, 23, 28, 1, 1, 0, 1, 1, 0),
-      dim = c(6L, 2L),
-      dimnames = list(NULL, c("time", "status")),
-      type = "right",
-      class = "Surv"
-    )
+  times <- c(9, 13, 13, 18, 23, 28)
+  cens <- c(1, 1, 0, 1, 1, 0)
+  surv_obj <- survival::Surv(times, cens)
 
   row_1 <- parsnip:::graf_weight_time_vec(surv_obj[1,,drop = FALSE], 1.0)
   row_5 <- parsnip:::graf_weight_time_vec(surv_obj, 1.0)

--- a/tests/testthat/test-parsnip-survival-standalone.R
+++ b/tests/testthat/test-parsnip-survival-standalone.R
@@ -61,6 +61,23 @@ test_that(".extract_surv_time()", {
   )
 })
 
+test_that(".extract_surv_time() vector results are unnamed", {
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9002")
+
+  times <- seq(1, 100, length.out = 5)
+  events <- c(1, 0, 1, 0, 1)
+
+  right_c <- survival::Surv(times, events)
+  left_c <- survival::Surv(times, events, type = "left")
+
+  expect_named(parsnip:::.extract_surv_time(right_c), NULL)
+  expect_named(parsnip:::.extract_surv_time(left_c), NULL)
+
+  # single observation
+  expect_named(parsnip:::.extract_surv_time(right_c[1]), NULL)
+  expect_named(parsnip:::.extract_surv_time(left_c[1]), NULL)
+})
+
 test_that(".extract_surv_status()", {
   times <- seq(1, 100, length.out = 5)
   times2 <- seq(100, 200, length.out = 5)
@@ -87,6 +104,30 @@ test_that(".extract_surv_status()", {
     parsnip:::.extract_surv_status(count_c),
     events
   )
+})
+
+test_that(".extract_surv_status() results are unnamed", {
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9002")
+
+  times <- seq(1, 100, length.out = 5)
+  times2 <- seq(100, 200, length.out = 5)
+  events <- c(1, 0, 1, 0, 1)
+
+  right_c <- survival::Surv(times, events)
+  left_c <- survival::Surv(times, events, type = "left")
+  intv_c <- survival::Surv(times, times2, events, type = "interval")
+  count_c <- survival::Surv(times, times2, events)
+
+  expect_named(parsnip:::.extract_surv_status(right_c), NULL)
+  expect_named(parsnip:::.extract_surv_status(left_c), NULL)
+  expect_named(parsnip:::.extract_surv_status(intv_c), NULL)
+  expect_named(parsnip:::.extract_surv_status(count_c), NULL)
+
+  # single observation
+  expect_named(parsnip:::.extract_surv_status(right_c[1]), NULL)
+  expect_named(parsnip:::.extract_surv_status(left_c[1]), NULL)
+  expect_named(parsnip:::.extract_surv_status(intv_c[1]), NULL)
+  expect_named(parsnip:::.extract_surv_status(count_c[1]), NULL)
 })
 
 test_that(".extract_surv_status() does not transform status for interval censoring", {


### PR DESCRIPTION
Light touch-up on #131 

The issue was that names popped up in the censoring weights for 1 observation with 1 eval time https://github.com/tidymodels/parsnip/issues/1023.

The solution was to unname the elements coming out of `.extract_surv_time()` and `.extract_surv_status()` https://github.com/tidymodels/parsnip/pull/1024

In #131 we added tests on `.parsnip:::graf_weight_time_vec()`, this PR adds tests on `.extract_surv_time()` and `.extract_surv_status()` since those were the functions modified in the solution.
