### PR TITLE
Updates for standardising the `$fit` slot of a censored/glmnet model

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           try(pak::pkg_install("tidymodels/baguette"))
           try(pak::pkg_install("tidymodels/bonsai"))
-          try(pak::pkg_install("tidymodels/censored"))
+          try(pak::pkg_install("tidymodels/censored#266"))
           try(pak::pkg_install("tidymodels/dials"))
           try(pak::pkg_install("tidymodels/discrim"))
           try(pak::pkg_install("tidymodels/hardhat"))

--- a/tests/testthat/_snaps/censored-case-weights.md
+++ b/tests/testthat/_snaps/censored-case-weights.md
@@ -9,7 +9,7 @@
 # proportional_hazards - glmnet censored case weights
 
     Code
-      wt_fit$fit$fit$call
+      wt_fit$fit$call
     Output
       glmnet::glmnet(x = data_obj$x, y = data_obj$y, family = "cox", 
           weights = weights, alpha = alpha, lambda = lambda)

--- a/tests/testthat/test-censored-case-weights.R
+++ b/tests/testthat/test-censored-case-weights.R
@@ -103,6 +103,7 @@ test_that('proportional_hazards - glmnet censored case weights', {
     set_mode("censored regression") %>%
     fit(Surv(time, event) ~ ., data = dat$full)
 
-  expect_snapshot(wt_fit$fit$fit$call)
-  expect_unequal(coef(unwt_fit$fit$fit), coef(wt_fit$fit$fit))
+  skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
+  expect_snapshot(wt_fit$fit$call)
+  expect_unequal(coef(unwt_fit$fit), coef(wt_fit$fit))
 })

--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -20,8 +20,9 @@ test_that("can `fit()` a censored workflow with a formula", {
 
   expect_s3_class(wf_fit$fit$fit, "model_fit")
 
+  skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_equal(
-    wf_fit$fit$fit$fit$fit$beta,
+    wf_fit$fit$fit$fit$beta,
     censored::coxnet_train(surv ~ ., data = lung)$fit$beta
   )
 })
@@ -66,8 +67,9 @@ test_that("can `fit()` a censored workflow with variables", {
 
   expect_s3_class(wf_fit$fit$fit, "model_fit")
 
+  skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_equal(
-    wf_fit$fit$fit$fit$fit$beta,
+    wf_fit$fit$fit$fit$beta,
     censored::coxnet_train(surv ~ ., data = lung)$fit$beta
   )
 })
@@ -89,8 +91,9 @@ test_that("can `fit()` a censored workflow with a recipe", {
 
   expect_s3_class(wf_fit$fit$fit, "model_fit")
 
+  skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_equal(
-    wf_fit$fit$fit$fit$fit$beta,
+    wf_fit$fit$fit$fit$beta,
     censored::coxnet_train(surv ~ ., data = lung)$fit$beta
   )
 })


### PR DESCRIPTION
updates for https://github.com/tidymodels/censored/pull/266