### PR TITLE
add tests for empty dots in predict.censoring_model_reverse_km()

### DIFF
--- a/tests/testthat/_snaps/parsnip-survival-censoring-model.md
+++ b/tests/testthat/_snaps/parsnip-survival-censoring-model.md
@@ -5,6 +5,16 @@
     Output
       reverse_km model for predicting the probability of censoring
 
+# predict.censoring_model_reverse_km checks empty dots
+
+    Code
+      predict(mod_fit$censor_probs, time = pred_times, invalid_arg = TRUE)
+    Condition
+      Error in `predict()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * invalid_arg = TRUE
+
 # Handle unknown censoring model
 
     Code

--- a/tests/testthat/test-parsnip-survival-censoring-model.R
+++ b/tests/testthat/test-parsnip-survival-censoring-model.R
@@ -71,6 +71,21 @@ test_that("predict with reverse Kaplan-Meier curves", {
   expect_equal(pred_vec, exp_pred)
 })
 
+test_that("predict.censoring_model_reverse_km checks empty dots", {
+  skip_if_not_installed("parsnip", minimum_version = "1.1.1.9006")
+
+  mod_fit <-
+    survival_reg() %>%
+    fit(Surv(time, status) ~ age + sex, data = lung)
+
+  pred_times <- (7:10) * 100
+
+  expect_snapshot(
+    error = TRUE,
+    predict(mod_fit$censor_probs, time = pred_times, invalid_arg = TRUE)
+  )
+})
+
 test_that("predict() can handle NA times", {
   mod_fit <-
     survival_reg() %>%


### PR DESCRIPTION
Related to https://github.com/tidymodels/parsnip/pull/1037