### PR TITLE
ensure racing functions warn informatively with unneeded `eval_time`

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -79,7 +79,7 @@ jobs:
           try(pak::pkg_install("tidymodels/tune#804"))
           try(pak::pkg_install("tidymodels/workflows"))
           try(pak::pkg_install("tidymodels/yardstick"))
-          try(pak::pkg_install("tidymodels/finetune"))
+          try(pak::pkg_install("tidymodels/finetune#94"))
           try(pak::pkg_install("business-science/modeltime"))
         shell: Rscript {0}
 

--- a/tests/testthat/_snaps/survival-tune_race_anova.md
+++ b/tests/testthat/_snaps/survival-tune_race_anova.md
@@ -88,3 +88,23 @@
       4    0.0891       brier_survi~ standard           NA 0.338    30 0.00480 Prepro~
       5    0.0944       brier_survi~ standard           NA 0.338    30 0.00480 Prepro~
 
+# race tuning (anova) - unneeded eval_time
+
+    Code
+      tune_res <- linear_reg(penalty = tune(), engine = "glmnet") %>% tune_race_anova(
+        mpg ~ ., resamples = vfold_cv(mtcars, 5), metrics = metric_set(rmse),
+        eval_time = 10)
+    Condition
+      Warning in `tune_race_anova()`:
+      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+
+---
+
+    Code
+      tune_res <- proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+        tune_race_anova(surv ~ ., resamples = vfold_cv(lung_surv, 5), metrics = metric_set(
+          concordance_survival), eval_time = 10)
+    Condition
+      Warning in `tune_race_anova()`:
+      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+

--- a/tests/testthat/_snaps/survival-tune_race_win_loss.md
+++ b/tests/testthat/_snaps/survival-tune_race_win_loss.md
@@ -125,3 +125,23 @@
       4        9.44e-11 brier_survi~ standard           NA 0.285    30 0.00426 Prepro~
       5        1   e-10 brier_survi~ standard           NA 0.285    30 0.00426 Prepro~
 
+# race tuning (W/L) - unneeded eval_time
+
+    Code
+      tune_res <- linear_reg(penalty = tune(), engine = "glmnet") %>%
+        tune_race_win_loss(mpg ~ ., resamples = vfold_cv(mtcars, 5), metrics = metric_set(
+          rmse), eval_time = 10)
+    Condition
+      Warning in `tune_race_win_loss()`:
+      Evaluation times are only required when the model mode is "censored regression" (and will be ignored).
+
+---
+
+    Code
+      tune_res <- proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+        tune_race_win_loss(surv ~ ., resamples = vfold_cv(lung_surv, 5), metrics = metric_set(
+          concordance_survival), eval_time = 10)
+    Condition
+      Warning in `tune_race_win_loss()`:
+      Evaluation times are only required when dynamic or integrated metrics are used (and will be ignored here).
+

--- a/tests/testthat/test-survival-tune_race_win_loss.R
+++ b/tests/testthat/test-survival-tune_race_win_loss.R
@@ -680,3 +680,38 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
     show_best(wl_mixed_res, metric = "brier_survival_integrated")
   )
 })
+
+
+test_that("race tuning (W/L) - unneeded eval_time", {
+  skip_if_not_installed("BradleyTerry2")
+  skip_if_not_installed("flexsurv")
+
+  lung_surv <- lung %>%
+    mutate(surv = Surv(time, status), .keep = "unused")
+
+  # mode is not censored regression
+  set.seed(2193)
+  expect_snapshot(
+    tune_res <-
+      linear_reg(penalty = tune(), engine = "glmnet") %>%
+      tune_race_win_loss(
+        mpg ~ .,
+        resamples = vfold_cv(mtcars, 5),
+        metrics = metric_set(rmse),
+        eval_time = 10
+      )
+  )
+
+  # static metric
+  set.seed(2193)
+  expect_snapshot(
+    tune_res <-
+      proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+      tune_race_win_loss(
+        surv ~ .,
+        resamples = vfold_cv(lung_surv, 5),
+        metrics = metric_set(concordance_survival),
+        eval_time = 10
+      )
+  )
+})


### PR DESCRIPTION
Tests for tidymodels/finetune#94.