### PR TITLE
Fix mismatch in bag_tree fit call

### DIFF
--- a/tests/testthat/_snaps/censored-case-weights.md
+++ b/tests/testthat/_snaps/censored-case-weights.md
@@ -1,3 +1,11 @@
+# bag_tree - rpart censored case weights
+
+    Code
+      wt_fit$fit$call
+    Output
+      bagging.data.frame(formula = Surv(time, event) ~ ., data = data, 
+          weights = weights, cp = ~0, minsplit = ~2)
+
 # proportional_hazards - glmnet censored case weights
 
     Code

--- a/tests/testthat/test-censored-case-weights.R
+++ b/tests/testthat/test-censored-case-weights.R
@@ -11,7 +11,9 @@ suppressPackageStartupMessages(library(censored))
 
 test_that('bag_tree - rpart censored case weights', {
   skip_if_not_installed("censored", "0.1.0")
-  skip("Need to rectify CI and local results - see #160")
+
+  # To make devtools::test_active_file() and devtools::test() do the same #185
+  library(baguette)
 
   dat <- make_cens_wts()
 


### PR DESCRIPTION
to close https://github.com/tidymodels/extratests/issues/160

After a LOT of dead ends. I figured it out! `library(baguette)` is being run in a `test_that()` in a previous test file, which then trigger some `parsnip::set_model_arg()` calls from {baguette}s `.onload()`. Since we started running only some tests, we are no longer triggering the `library(baguette)` call.

This PR fixes that by added a `library(baguette)` in the affected test. I added an issue $186 so we can think about how we can deal with this is a better way.

``` r
library(tidymodels)
library(censored)
#> Loading required package: survival

make_cens_wts <- function() {
  data(time_to_million, package = "censored", envir = rlang::current_env())
  
  set.seed(1)
  time_to_million <- time_to_million[1:100, c("time", "event", "released_theaters", "rated")]
  wts <- runif(nrow(time_to_million))
  wts <- ifelse(wts < 1/5, 0, 1)
  cens_subset <- time_to_million[wts != 0, ]
  wts <- importance_weights(wts)
  
  list(wts = wts, subset = cens_subset, full = time_to_million)
}

dat <- make_cens_wts()

wt_fit <-
  bag_tree() %>%
  set_engine("rpart") %>%
  set_mode("censored regression") %>%
  fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)


wt_fit$fit$call
#> bagging.data.frame(formula = Surv(time, event) ~ ., data = data, 
#>     weights = weights)

library(baguette)

wt_fit <-
  bag_tree() %>%
  set_engine("rpart") %>%
  set_mode("censored regression") %>%
  fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)


wt_fit$fit$call
#> bagging.data.frame(formula = Surv(time, event) ~ ., data = data, 
#>     weights = weights, cp = ~0, minsplit = ~2)
```