### PR TITLE
Remove test on augment() on aorsf models

### DIFF
--- a/tests/testthat/test-survival-augment.R
+++ b/tests/testthat/test-survival-augment.R
@@ -54,36 +54,6 @@ test_that('augmenting survival models ', {
   )
 })
 
-test_that("augment() for survival models skips unavailble prediction type", {
-  skip_if_not_installed("parsnip", minimum_version = "1.1.0.9001")
-  skip_if_not_installed("prodlim")
-  skip_if_not_installed("aorsf")
-
-  set.seed(1)
-  sim_dat <- prodlim::SimSurv(500) %>%
-    mutate(event_time = Surv(time, event)) %>%
-    select(event_time, X1, X2)
-
-  time_points <- c(1, 5, 10)
-
-  # this engine does not provide predictions of type = "time"
-  rf_fit <-
-    rand_forest() %>%
-    set_engine("aorsf") %>%
-    set_mode("censored regression") %>%
-    fit(event_time ~ ., data = sim_dat)
-
-  rf_aug <- augment(rf_fit, new_data = sim_dat, eval_time = time_points)
-  expect_equal(nrow(rf_aug), nrow(sim_dat))
-  expect_equal(names(rf_aug), c(".pred", "event_time", "X1", "X2"))
-  expect_true(is.list(rf_aug$.pred))
-  expect_equal(
-    names(rf_aug$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_time", ".pred_censored",
-      ".weight_censored")
-  )
-})
-
 test_that("augment() for survival models errors if eval_time is missing", {
   skip_if_not_installed("parsnip", minimum_version = "1.1.1.9008")
 


### PR DESCRIPTION
This was testing that `augment()` would not trip up if an engine didn't provide predictions with `type = "time"` or `type = "survival"` but aorsf was the only one missing. Now* all engines for all models in censored provide predictions for those two types.

*Now = after https://github.com/tidymodels/censored/pull/308 is merged