### PR TITLE
stop excessive warnings when checking for spark

### DIFF
--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -19,7 +19,8 @@ run_glmnet <- utils::compareVersion('3.6.0', as.character(getRversion())) > 0
 
 spark_not_installed <- function() {
 
-  need_install <- try(sparklyr::spark_install_find(), silent = TRUE)
+  quietly_inquire_re_spark <- purrr:::quietly(sparklyr::spark_install_find)()
+  need_install <- try(quietly_inquire_re_spark(), silent = TRUE)
 
   if(inherits(need_install, "try-error")) {
     need_install <- TRUE


### PR DESCRIPTION
We were getting sooooo many of these: 

> Warning message:
> In sparklyr::spark_install_find() :
>   The Spark version specified may not be available.
> Please consider running `spark_available_versions()` to list all known available Spark versions.

