### PR TITLE
Add test on `int_pctl()` for survival models with a subset of evaluation times

### DIFF
--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -76,11 +76,11 @@ jobs:
           try(pak::pkg_install("tidymodels/stacks"))
           try(pak::pkg_install("tidymodels/themis"))
           try(pak::pkg_install("tidymodels/tidymodels"))
-          try(pak::pkg_install("tidymodels/tune"))
           try(pak::pkg_install("tidymodels/workflows"))
           try(pak::pkg_install("tidymodels/yardstick"))
           try(pak::pkg_install("tidymodels/finetune"))
           try(pak::pkg_install("business-science/modeltime"))
+          try(pak::pkg_install("tidymodels/tune#861"))
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
For https://github.com/tidymodels/tune/issues/856: to show that the subsetting of `eval_time` still works after removing the `eval_time` argument from lower level functions like `.estimate_metrics()`.

Plan is to have the CI run through, then again with the branch with changes.