### PR TITLE
use cron job to keep Actions alive after inactivity

### DIFF
--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -1,26 +1,25 @@
-# keeps Actions alive by pushing a dummy commit to main after 45 days
-# of inactivity
+# keeps Actions alive by pushing a dummy commit to main once a month
 name: Keep Actions alive
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 1 * *'
+
 jobs:
-  main-job:
-    name: Main Job
+  empty-commit:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-  keepalive-job:
-    name: Keep alive
-    if: ${{ always() }}
-    needs: main-job
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2
-        with:
-          use_api: false
-          committer_username: ${{ github.repository_owner }}
-          committer_email: ${{ github.repository_owner }}@users.noreply.github.com
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Make an empty commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "Monthly empty commit"
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin main

--- a/.github/workflows/keep-alive.yaml
+++ b/.github/workflows/keep-alive.yaml
@@ -1,0 +1,26 @@
+# keeps Actions alive by pushing a dummy commit to main after 45 days
+# of inactivity
+name: Keep Actions alive
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  main-job:
+    name: Main Job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+  keepalive-job:
+    name: Keep alive
+    if: ${{ always() }}
+    needs: main-job
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2
+        with:
+          use_api: false
+          committer_username: ${{ github.repository_owner }}
+          committer_email: ${{ github.repository_owner }}@users.noreply.github.com


### PR DESCRIPTION
~~Uses [gautamkrishnar/keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to keep Actions alive after a period of inactivity by pushing a dummy commit to main. Runs nightly, but only pushes after 45 days of inactivity. Based on [this example](https://github.com/gautamkrishnar/keepalive-workflow?tab=readme-ov-file#dummy-commit-keepalive-workflow-for-github-actions-users).~~

EDIT: rewritten to avoid external dependency. Instead of pushing after 45 days of inactivity, just pushes once a month regardless of repo activity.