### PR TITLE
address GH check failures

### DIFF
--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -6,7 +6,7 @@ library(tidymodels)
 suppressPackageStartupMessages(library(censored))
 
 test_that("can `fit()` a censored workflow with a formula", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -28,7 +28,7 @@ test_that("can `fit()` a censored workflow with a formula", {
 })
 
 test_that("can `fit()` a censored workflow with a model formula", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -53,7 +53,7 @@ test_that("can `fit()` a censored workflow with a model formula", {
 })
 
 test_that("can `fit()` a censored workflow with variables", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -75,7 +75,7 @@ test_that("can `fit()` a censored workflow with variables", {
 })
 
 test_that("can `fit()` a censored workflow with a recipe", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -99,7 +99,7 @@ test_that("can `fit()` a censored workflow with a recipe", {
 })
 
 test_that("can `predict()` a censored workflow with a formula", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -133,7 +133,7 @@ test_that("can `predict()` a censored workflow with a formula", {
 })
 
 test_that("can `predict()` a censored workflow with a model formula", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -169,7 +169,7 @@ test_that("can `predict()` a censored workflow with a model formula", {
 })
 
 test_that("can `predict()` a censored workflow with variables", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
@@ -203,7 +203,7 @@ test_that("can `predict()` a censored workflow with variables", {
 })
 
 test_that("can `predict()` a censored workflow with a recipe", {
-  lung <- lung %>%
+  lung <- survival::lung %>%
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 


### PR DESCRIPTION
Currently, on Ubuntu we're seeing:

```
── 1. Error ('test-survival-workflows.R:77:1'): can `fit()` a censored workflow 
<CStackOverflowError/stackOverflowError/error/condition>
Error: Error: C stack usage  15938740 is too close to the limit

── 2. Error ('test-survival-workflows.R:205:1'): can `predict()` a censored work
<CStackOverflowError/stackOverflowError/error/condition>
Error: Error: C stack usage  15938740 is too close to the limit
```

and on Windows:

```
══ Failed ══════════════════════════════════════════════════════════════════════
Error: Error in as_function(.f, env = global_env()) : node stack overflow
Calls: test_check ... .rlang_purrr_map_mold -> as_function -> is_function
Execution halted
```

I can replicate the C stack usage error locally and namespacing the dataset (which is likely good test hygiene anyway) seems to resolve it. The error comes from `tidyr::drop_na()` after having ran the `drop_na() %>% mutate(...)` code once. I would _guess_ that this first commit resolves the Ubuntu error but I don't have much intuition on the Windows one yet.

`.rlang_purrr_map_mold` is part of the `import-purrr-standalone`. Neither of workflows or censored have GH changes in the past 3 days, and none of testthat, dplyr, tidyr, or survival have recently released CRAN versions.