### PR TITLE
changes for CRAN dials for regularization.factor

### DIFF
--- a/tests/testthat/test-engine-parameters-ranger.R
+++ b/tests/testthat/test-engine-parameters-ranger.R
@@ -20,7 +20,6 @@ rs <- bootstraps(mtcars, times = 5)
 ## -----------------------------------------------------------------------------
 
 test_that('grid search', {
-  # pending tidymodels/dials#347
   skip_if_not_installed("dials", minimum_version = "1.3.0.9001")
 
   set.seed(2893)
@@ -39,14 +38,19 @@ test_that('grid search', {
 ## -----------------------------------------------------------------------------
 
 test_that('Bayes search', {
-  # pending tidymodels/dials#347
   skip_if_not_installed("dials", minimum_version = "1.3.0.9001")
 
   set.seed(2893)
   expect_error(
     rf_search <-
       rf_mod %>%
-      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2, param_info = rf_param) %>%
+      tune_bayes(
+        mpg ~ .,
+        resamples = rs,
+        initial = 3,
+        iter = 2,
+        param_info = rf_param
+      ) %>%
       suppressMessages(),
     regex = NA
   )

--- a/tests/testthat/test-engine-parameters-ranger.R
+++ b/tests/testthat/test-engine-parameters-ranger.R
@@ -9,6 +9,11 @@ rf_mod <-
   ) %>%
   set_mode("regression")
 
+rf_param <-
+  rf_mod %>%
+  extract_parameter_set_dials() %>%
+  update(regularization.factor = regularization_factor(c(.1, 1)))
+
 set.seed(192)
 rs <- bootstraps(mtcars, times = 5)
 
@@ -22,7 +27,7 @@ test_that('grid search', {
   expect_error(
     rf_tune <-
       rf_mod %>%
-      tune_grid(mpg ~ ., resamples = rs, grid = 4) %>%
+      tune_grid(mpg ~ ., resamples = rs, grid = 4, param_info = rf_param) %>%
       suppressMessages(),
     regex = NA
   )
@@ -41,7 +46,7 @@ test_that('Bayes search', {
   expect_error(
     rf_search <-
       rf_mod %>%
-      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2) %>%
+      tune_bayes(mpg ~ ., resamples = rs, initial = 3, iter = 2, param_info = rf_param) %>%
       suppressMessages(),
     regex = NA
   )


### PR DESCRIPTION
With changes to the `inclusive` data for a numeric parameter, the CRAN version of dials chokes on two specific tests (the devel version has a fix). 

This PR updates the test to change the parameter range to stop the failure. The change does not alter the intent of the unit test (for tuning engine parameters), just side-steps the short-term issue of zero values for the `regularization.factor` argument to `ranger()`