### PR TITLE
Undo tmp changes for dimRed

### DIFF
--- a/.github/workflows/CRAN-R-CMD-check.yaml
+++ b/.github/workflows/CRAN-R-CMD-check.yaml
@@ -56,12 +56,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Install dimRed versions
-        run: |
-          # Temp due to dimRed removal from CRAN
-          try(pak::pkg_install("gdkrmr/dimRed"))
-        shell: Rscript {0}
-
       - uses: r-lib/actions/check-r-package@v2
 
       - name: Notify slack fail

--- a/.github/workflows/GH-R-CMD-check.yaml
+++ b/.github/workflows/GH-R-CMD-check.yaml
@@ -82,8 +82,14 @@ jobs:
             "tidymodels/poissonreg",
             "tidymodels/rules"
           )))
-          # Temp due to dimRed removal from CRAN
-          try(pak::pkg_install("gdkrmr/dimRed"))
+          try(pak::pkg_install(c(
+            "tidymodels/dials",
+            "tidymodels/hardhat",
+            "tidymodels/modeldata",
+            "tidymodels/rsample",
+            "tidymodels/spatialsample",
+            "tidymodels/yardstick"
+          )))
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,7 @@ Authors@R: c(
 Description: A place for units tests that depend on multiple packages.
 License: MIT + file LICENSE
 Depends: 
-    tidymodels,
-    pak
+    tidymodels
 Suggests: 
     aorsf,
     baguette,
@@ -22,6 +21,7 @@ Suggests:
     conflicted,
     coin,
     dials,
+    dimRed,
     discrim,
     doParallel,
     dplyr,


### PR DESCRIPTION
This undoes the changes from #232 as dimRed is back on CRAN.

I think we've not been testing with the dev versions of the tidymodels packages at the start of the food chain.