### PR TITLE
ggplot2::get_labels()

### DIFF
--- a/tests/testthat/_snaps/survival-tune-autoplot.md
+++ b/tests/testthat/_snaps/survival-tune-autoplot.md
@@ -1,3 +1,73 @@
+# autoplot-ting survival models with static metric
+
+    Code
+      ggplot2::get_labs(stc_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+          trees 
+      "# Trees" 
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(stc_perf)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $ymin
+      [1] "mean - const * std_err"
+      
+      $ymax
+      [1] "mean + const * std_err"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(stc_param)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "# Trees"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # autoplot-ting survival models with dynamic metric
 
     Code
@@ -18,6 +88,162 @@
       Warning:
       `eval_time` is not used with `autoplot(..., type = 'parameters')`.
 
+---
+
+    Code
+      ggplot2::get_labs(dyn_mult_grid)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] ""
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] ""
+      
+      $y
+      [1] "brier_survival @10"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_mult_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] ""
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_perf)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "brier_survival @10"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] ""
+      
+      $y
+      [1] "brier_survival @10"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_param)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      dyn_mult_param <- autoplot(bayes_dynamic_res, type = "parameters", eval_time = c(
+        10, 15))
+    Condition
+      Warning:
+      `eval_time` is not used with `autoplot(..., type = 'parameters')`.
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_mult_param)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # autoplot-ting survival models with different metric types
 
     Code
@@ -28,6 +254,156 @@
     Condition
       Warning in `tune_bayes()`:
       4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
+
+---
+
+    Code
+      mix_mult_param <- autoplot(bayes_mixed_res, type = "parameters", eval_time = c(
+        10, 15))
+    Condition
+      Warning:
+      `eval_time` is not used with `autoplot(..., type = 'parameters')`.
+
+---
+
+    Code
+      ggplot2::get_labs(mix_mult_grid)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+        tree_depth 
+      "Tree Depth" 
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+        tree_depth 
+      "Tree Depth" 
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_mult_marginal)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+        tree_depth 
+      "Tree Depth" 
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_perf)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "mean"
+      
+      $y.sec
+      NULL
+      
+      $ymin
+      [1] "mean - const * std_err"
+      
+      $ymax
+      [1] "mean + const * std_err"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_mult_perf)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "mean"
+      
+      $y.sec
+      NULL
+      
+      $ymin
+      [1] "mean - const * std_err"
+      
+      $ymax
+      [1] "mean + const * std_err"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_param)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Iteration"
+      
+      $y
+      [1] "Tree Depth"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
 
 ---
 

--- a/tests/testthat/_snaps/survival-tune_race_anova.md
+++ b/tests/testthat/_snaps/survival-tune_race_anova.md
@@ -1,3 +1,58 @@
+# race tuning (anova) survival models with static metric
+
+    Code
+      ggplot2::get_labs(stc_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(stc_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # race tuning (anova) survival models with integrated metric
 
     Code
@@ -7,13 +62,234 @@
       Warning in `show_best()`:
       `eval_time` is only used for dynamic survival metrics.
 
+---
+
+    Code
+      ggplot2::get_labs(int_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "brier_survival_integrated"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(int_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "brier_survival_integrated"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # race tuning (anova) survival models with dynamic metrics
 
     4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
 
+---
+
+    Code
+      ggplot2::get_labs(dyn_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "brier_survival"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "brier_survival @10"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # race tuning (anova) survival models with mixture of metric types
 
     4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
+
+---
+
+    Code
+      ggplot2::get_labs(mix_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "brier_survival"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_multi_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] ""
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(mix_alt_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
 
 ---
 

--- a/tests/testthat/_snaps/survival-tune_race_win_loss.md
+++ b/tests/testthat/_snaps/survival-tune_race_win_loss.md
@@ -1,3 +1,58 @@
+# race tuning (win_loss) survival models with static metric
+
+    Code
+      ggplot2::get_labs(stc_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(stc_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "concordance_survival"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
+
 # race tuning (win_loss) survival models with integrated metric
 
     Code
@@ -6,6 +61,61 @@
     Condition
       Warning in `show_best()`:
       `eval_time` is only used for dynamic survival metrics.
+
+---
+
+    Code
+      ggplot2::get_labs(int_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "brier_survival_integrated"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(int_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "brier_survival_integrated"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
 
 # race tuning (win_loss) survival models with dynamic metrics
 
@@ -16,6 +126,61 @@
     Condition
       Warning in `tune_race_win_loss()`:
       4 evaluation times are available; the first will be used (i.e. `eval_time = 10`).
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_race_plot)
+    Output
+      $x.sec
+      NULL
+      
+      $x
+      [1] "Analysis Stage"
+      
+      $y
+      [1] "brier_survival"
+      
+      $y.sec
+      NULL
+      
+      $group
+      [1] ".config"
+      
+      $colour
+      [1] ".config"
+      
+      $alt
+      [1] ""
+      
+
+---
+
+    Code
+      ggplot2::get_labs(dyn_autoplot)
+    Output
+      $alpha
+      [1] "# resamples"
+      
+      $size
+      [1] "# resamples"
+      
+      $x.sec
+      NULL
+      
+      $x
+                  cost_complexity 
+      "Cost-Complexity Parameter" 
+      
+      $y
+      [1] "brier_survival @10"
+      
+      $y.sec
+      NULL
+      
+      $alt
+      [1] ""
+      
 
 # race tuning (win_loss) survival models with mixture of metric types
 
@@ -60,6 +225,60 @@
       3        8.91e-11 brier_survival          1 0.177    30 0.00707
       4        9.44e-11 brier_survival          1 0.177    30 0.00707
       5        1   e-10 brier_survival          1 0.177    30 0.00707
+
+---
+
+    Code
+      show_best(wl_mixed_res, metric = "brier_survival", eval_time = c(1.1)) %>%
+        select(-.estimator, -.config)
+    Condition
+      Error in `show_best()`:
+      ! Evaluation time 1.1 is not in the results.
+
+---
+
+    Code
+      show_best(wl_mixed_res, metric = "brier_survival", eval_time = c(1, 3)) %>%
+        select(-.estimator, -.config)
+    Condition
+      Warning in `show_best()`:
+      2 evaluation times are available; the first will be used (i.e. `eval_time = 1`).
+    Output
+      # A tibble: 5 x 6
+        cost_complexity .metric        .eval_time  mean     n std_err
+                  <dbl> <chr>               <dbl> <dbl> <int>   <dbl>
+      1        7.94e-11 brier_survival          1 0.177    30 0.00707
+      2        8.41e-11 brier_survival          1 0.177    30 0.00707
+      3        8.91e-11 brier_survival          1 0.177    30 0.00707
+      4        9.44e-11 brier_survival          1 0.177    30 0.00707
+      5        1   e-10 brier_survival          1 0.177    30 0.00707
+
+---
+
+    Code
+      res <- show_best(wl_mixed_res, metric = "unused_metric", eval_time = c(1, 3)) %>%
+        select(-.estimator, -.config)
+    Condition
+      Error in `show_best()`:
+      ! "unused_metric" was not in the metric set. Please choose from: "brier_survival", "brier_survival_integrated", and "concordance_survival".
+
+---
+
+    Code
+      show_best(wl_mixed_res, metric = "brier_survival_integrated") %>% select(
+        -.estimator, -.config)
+    Condition
+      Warning:
+      Metric "brier_survival" was used to evaluate model candidates in the race but "brier_survival_integrated" has been chosen to rank the candidates. These results may not agree with the race.
+    Output
+      # A tibble: 5 x 6
+        cost_complexity .metric                   .eval_time  mean     n std_err
+                  <dbl> <chr>                          <dbl> <dbl> <int>   <dbl>
+      1        7.94e-11 brier_survival_integrated         NA 0.285    30 0.00426
+      2        8.41e-11 brier_survival_integrated         NA 0.285    30 0.00426
+      3        8.91e-11 brier_survival_integrated         NA 0.285    30 0.00426
+      4        9.44e-11 brier_survival_integrated         NA 0.285    30 0.00426
+      5        1   e-10 brier_survival_integrated         NA 0.285    30 0.00426
 
 ---
 

--- a/tests/testthat/test-survival-tune-autoplot.R
+++ b/tests/testthat/test-survival-tune-autoplot.R
@@ -91,10 +91,7 @@ test_that("autoplot-ting survival models with static metric", {
     rlang::expr_text(stc_marginal$mapping$y),
     "~mean"
   )
-  expect_equal(
-    stc_marginal$labels,
-    list(x = c(trees = "# Trees"), y = "concordance_survival")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -120,13 +117,8 @@ test_that("autoplot-ting survival models with static metric", {
     rlang::expr_text(stc_perf$mapping$y),
     "~mean"
   )
-  expect_equal(
-    stc_perf$labels,
-    list(y = "concordance_survival",
-         x = "Iteration",
-         ymin = "mean - const * std_err",
-         ymax = "mean + const * std_err")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_perf))
+
   # ------------------------------------------------------------------------------
 
   stc_param <- autoplot(sa_static_res, type = "parameters")
@@ -146,10 +138,7 @@ test_that("autoplot-ting survival models with static metric", {
     rlang::expr_text(stc_param$mapping$y),
     "~value"
   )
-  expect_equal(
-    stc_param$labels,
-    list(y = "# Trees", x = "Iteration")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_param))
 
 
 })
@@ -243,11 +232,7 @@ test_that("autoplot-ting survival models with integrated metric", {
     rlang::expr_text(int_grid$mapping$group),
     "~`Proportion of Lasso Penalty`"
   )
-  expect_equal(
-    map(int_grid$labels, as.character),
-    list(y = "brier_survival_integrated", colour = "Proportion of Lasso Penalty",
-         x = "Amount of Regularization", group = "Proportion of Lasso Penalty")
-  )
+  expect_snapshot(ggplot2::get_labs(int_grid))
 
   # ------------------------------------------------------------------------------
 
@@ -275,10 +260,7 @@ test_that("autoplot-ting survival models with integrated metric", {
     rlang::expr_text(int_marginal$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    map(int_marginal$labels, as.character),
-    list(y = "brier_survival_integrated", x = "")
-  )
+  expect_snapshot(ggplot2::get_labs(int_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -305,13 +287,7 @@ test_that("autoplot-ting survival models with integrated metric", {
     rlang::expr_text(int_perf$mapping$y),
     "~mean"
   )
-  expect_equal(
-    int_perf$labels,
-    list(y = "brier_survival_integrated",
-         x = "Iteration",
-         ymin = "mean - const * std_err",
-         ymax = "mean + const * std_err")
-  )
+  expect_snapshot(ggplot2::get_labs(int_perf))
 
   # ------------------------------------------------------------------------------
 
@@ -336,10 +312,7 @@ test_that("autoplot-ting survival models with integrated metric", {
     rlang::expr_text(int_param$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    int_param$labels,
-    list(y = "", x = "Iteration")
-  )
+  expect_snapshot(ggplot2::get_labs(int_param))
 
 
 })
@@ -434,10 +407,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_grid$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    map(dyn_grid$labels, as.character),
-    list(y = "brier_survival @10", x = "")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_grid))
 
   # ------------------------------------------------------------------------------
 
@@ -478,10 +448,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     names(dyn_mult_grid$facet$params$cols),
     "name"
   )
-  expect_equal(
-    map(dyn_mult_grid$labels, as.character),
-    list(y = "", x = "")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_mult_grid))
 
   # ------------------------------------------------------------------------------
 
@@ -509,10 +476,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_marginal$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    map(dyn_marginal$labels, as.character),
-    list(y = "brier_survival @10", x = "")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -554,10 +518,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     names(dyn_mult_marginal$facet$params$cols),
     "name"
   )
-  expect_equal(
-    map(dyn_mult_marginal$labels, as.character),
-    list(y = "", x = "")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_mult_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -586,11 +547,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_perf$mapping$y),
     "~mean"
   )
-  expect_equal(
-    dyn_perf$labels,
-    list(y = "brier_survival @10",
-         x = "Iteration")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_perf))
 
   # ------------------------------------------------------------------------------
 
@@ -629,10 +586,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_marginal$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    dyn_mult_perf$labels,
-    list(x = "Iteration", y = "mean")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -657,10 +611,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_param$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    dyn_param$labels,
-    list(y = "", x = "Iteration")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_param))
 
   # ------------------------------------------------------------------------------
 
@@ -687,10 +638,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_mult_param$facet$params$facets$name),
     "~name"
   )
-  expect_equal(
-    dyn_mult_param$labels,
-    list(y = "", x = "Iteration")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_mult_param))
 
 })
 
@@ -811,10 +759,7 @@ test_that("autoplot-ting survival models with different metric types", {
     sort(unique(mix_grid$data$.metric)),
     c("brier_survival @10", "brier_survival_integrated", "concordance_survival")
   )
-  expect_equal(
-    map(mix_grid$labels, as.character),
-    list(x = "Tree Depth", y = "")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_grid))
 
   # ------------------------------------------------------------------------------
 
@@ -852,10 +797,7 @@ test_that("autoplot-ting survival models with different metric types", {
     c("brier_survival @ 1", "brier_survival @10", "brier_survival_integrated",
       "concordance_survival")
   )
-  expect_equal(
-    map(mix_mult_grid$labels, as.character),
-    list(x = "Tree Depth", y = "")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_mult_grid))
 
   # ------------------------------------------------------------------------------
 
@@ -883,10 +825,7 @@ test_that("autoplot-ting survival models with different metric types", {
     c("brier_survival @10", "brier_survival_integrated",
       "concordance_survival")
   )
-  expect_equal(
-    map(mix_marginal$labels, as.character),
-    list(x = "Tree Depth", y = "")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -915,10 +854,7 @@ test_that("autoplot-ting survival models with different metric types", {
     c("brier_survival @ 1", "brier_survival @ 5", "brier_survival_integrated",
       "concordance_survival")
   )
-  expect_equal(
-    map(mix_mult_marginal$labels, as.character),
-    list(x = "Tree Depth", y = "")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_mult_marginal))
 
   # ------------------------------------------------------------------------------
 
@@ -954,12 +890,7 @@ test_that("autoplot-ting survival models with different metric types", {
     rlang::expr_text(mix_perf$mapping$y),
     "~mean"
   )
-  expect_equal(
-    mix_perf$labels,
-    list(x = "Iteration", y = "mean",
-         ymin = "mean - const * std_err",
-         ymax = "mean + const * std_err")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_perf))
 
   # ------------------------------------------------------------------------------
 
@@ -999,12 +930,7 @@ test_that("autoplot-ting survival models with different metric types", {
     rlang::expr_text(mix_mult_perf$mapping$y),
     "~mean"
   )
-  expect_equal(
-    mix_mult_perf$labels,
-    list(x = "Iteration", y = "mean",
-         ymin = "mean - const * std_err",
-         ymax = "mean + const * std_err")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_mult_perf))
 
   # ------------------------------------------------------------------------------
 
@@ -1025,10 +951,8 @@ test_that("autoplot-ting survival models with different metric types", {
     rlang::expr_text(mix_param$mapping$y),
     "~value"
   )
-  expect_equal(
-    mix_param$labels,
-    list(y = "Tree Depth", x = "Iteration")
-  )
+
+  expect_snapshot(ggplot2::get_labs(mix_param))
 
   expect_snapshot(
     mix_mult_param <- autoplot(bayes_mixed_res, type = "parameters", eval_time = c(10, 15))

--- a/tests/testthat/test-survival-tune_race_anova.R
+++ b/tests/testthat/test-survival-tune_race_anova.R
@@ -7,6 +7,7 @@ skip_if_not_installed("censored", minimum_version = "0.2.0.9000")
 skip_if_not_installed("tune", minimum_version = "1.1.2.9020")
 skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
 skip_if_not_installed("finetune", minimum_version = "1.1.0.9005")
+skip_if_not_installed("ggplot2", minimum_version = "3.5.2.9002")
 
 test_that("race tuning (anova) survival models with static metric", {
   skip_if_not_installed("BradleyTerry2")
@@ -95,11 +96,7 @@ test_that("race tuning (anova) survival models with static metric", {
     rlang::expr_text(stc_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    stc_race_plot$labels,
-    list(y = "concordance_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -124,11 +121,7 @@ test_that("race tuning (anova) survival models with static metric", {
     rlang::expr_text(stc_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    stc_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "concordance_survival",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_autoplot))
 
   # test metric collection -----------------------------------------------------
 
@@ -311,11 +304,7 @@ test_that("race tuning (anova) survival models with integrated metric", {
     rlang::expr_text(int_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    int_race_plot$labels,
-    list(y = "brier_survival_integrated", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(int_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -340,11 +329,7 @@ test_that("race tuning (anova) survival models with integrated metric", {
     rlang::expr_text(int_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    int_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "brier_survival_integrated",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(int_autoplot))
 
   # test metric collection -----------------------------------------------------
 
@@ -552,11 +537,7 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
     rlang::expr_text(dyn_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    dyn_race_plot$labels,
-    list(y = "brier_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -581,12 +562,7 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
     rlang::expr_text(dyn_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    dyn_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "brier_survival @10",  alpha = "# resamples", size = "# resamples")
-  )
-
+  expect_snapshot(ggplot2::get_labs(dyn_autoplot))
 
   # test metric collection -----------------------------------------------------
 
@@ -794,11 +770,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
     rlang::expr_text(mix_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    mix_race_plot$labels,
-    list(y = "brier_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -835,11 +807,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
       "concordance_survival")
   )
 
-  expect_equal(
-    mix_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_autoplot))
 
 
   ###
@@ -877,11 +845,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
       "concordance_survival")
   )
 
-  expect_equal(
-    mix_multi_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_multi_autoplot))
 
   ###
 
@@ -907,11 +871,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
     "~mean"
   )
 
-  expect_equal(
-    mix_alt_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "concordance_survival",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_alt_autoplot))
 
   # test metric collection -----------------------------------------------------
 

--- a/tests/testthat/test-survival-tune_race_anova.R
+++ b/tests/testthat/test-survival-tune_race_anova.R
@@ -7,7 +7,7 @@ skip_if_not_installed("censored", minimum_version = "0.2.0.9000")
 skip_if_not_installed("tune", minimum_version = "1.1.2.9020")
 skip_if_not_installed("yardstick", minimum_version = "1.2.0.9001")
 skip_if_not_installed("finetune", minimum_version = "1.1.0.9005")
-skip_if_not_installed("ggplot2", minimum_version = "3.5.2.9002")
+
 
 test_that("race tuning (anova) survival models with static metric", {
   skip_if_not_installed("BradleyTerry2")

--- a/tests/testthat/test-survival-tune_race_win_loss.R
+++ b/tests/testthat/test-survival-tune_race_win_loss.R
@@ -93,11 +93,7 @@ test_that("race tuning (win_loss) survival models with static metric", {
     rlang::expr_text(stc_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    stc_race_plot$labels,
-    list(y = "concordance_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -122,11 +118,7 @@ test_that("race tuning (win_loss) survival models with static metric", {
     rlang::expr_text(stc_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    stc_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "concordance_survival",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(stc_autoplot))
 
   # test metric collection -----------------------------------------------------
 
@@ -309,11 +301,7 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
     rlang::expr_text(int_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    int_race_plot$labels,
-    list(y = "brier_survival_integrated", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(int_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -338,11 +326,7 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
     rlang::expr_text(int_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    int_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "brier_survival_integrated",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(int_autoplot))
 
   # test metric collection
 
@@ -536,11 +520,7 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
     rlang::expr_text(dyn_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    dyn_race_plot$labels,
-    list(y = "brier_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -565,11 +545,7 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
     rlang::expr_text(dyn_autoplot$mapping$y),
     "~mean"
   )
-  expect_equal(
-    dyn_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "brier_survival @10",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(dyn_autoplot))
 
 
   # test metric collection -----------------------------------------------------
@@ -771,11 +747,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
     rlang::expr_text(mix_race_plot$mapping$colour),
     "~.config"
   )
-  expect_equal(
-    mix_race_plot$labels,
-    list(y = "brier_survival", x = "Analysis Stage", group = ".config",
-         colour = ".config")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_race_plot))
 
   # test autoplot --------------------------------------------------------------
 
@@ -812,11 +784,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
       "concordance_survival")
   )
 
-  expect_equal(
-    mix_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_autoplot))
 
   ###
 
@@ -853,11 +821,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
       "concordance_survival")
   )
 
-  expect_equal(
-    mix_multi_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_multi_autoplot))
 
   ###
 
@@ -883,11 +847,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
     "~mean"
   )
 
-  expect_equal(
-    mix_alt_autoplot$labels,
-    list(x = c(cost_complexity = "Cost-Complexity Parameter"),
-         y = "concordance_survival",  alpha = "# resamples", size = "# resamples")
-  )
+  expect_snapshot(ggplot2::get_labs(mix_alt_autoplot))
 
   # test metric collection -----------------------------------------------------
 


### PR DESCRIPTION
Updating ggplot2 object tests to use `get_labels()`. 

Tests will still fail for unrelated reasons (e.g. column order changes etc) on GH tests but these are needed