### PR TITLE
making some tests insensitive to column order, survival tests

### DIFF
--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -28,3 +28,10 @@ spark_not_installed <- function() {
   }
   need_install
 }
+
+# ------------------------------------------------------------------------------
+
+expect_ptype <- function(x, ptype) {
+  expect_equal(x[0, names(ptype)], ptype)
+}
+

--- a/tests/testthat/test-survival-augment.R
+++ b/tests/testthat/test-survival-augment.R
@@ -32,12 +32,17 @@ test_that("augmenting survival models", {
 
   sr_aug <- augment(sr_fit, new_data = sim_tr, eval_time = time_points)
   expect_equal(nrow(sr_aug), nrow(sim_tr))
-  expect_equal(names(sr_aug), c(".pred", ".pred_time", "event_time", "X1", "X2"))
+  expect_named(
+    sr_aug,
+    c(".pred", ".pred_time", "event_time", "X1", "X2"),
+    ignore.order = TRUE
+  )
   expect_true(is.list(sr_aug$.pred))
-  expect_equal(
-    names(sr_aug$.pred[[1]]),
+  expect_named(
+    sr_aug$.pred[[1]],
     c(".eval_time", ".pred_survival", ".weight_time", ".pred_censored",
-      ".weight_censored")
+      ".weight_censored"),
+    ignore.order = TRUE
   )
 
   # proportional_hazards() -----------------------------------------------------
@@ -49,12 +54,17 @@ test_that("augmenting survival models", {
 
   glmn_aug <- augment(glmn_fit, new_data = sim_tr, eval_time = time_points)
   expect_equal(nrow(glmn_aug), nrow(sim_tr))
-  expect_equal(names(glmn_aug), c(".pred", ".pred_time", "event_time", "X1", "X2"))
+  expect_named(
+    glmn_aug,
+    c(".pred", ".pred_time", "event_time", "X1", "X2"),
+    ignore.order = TRUE
+  )
   expect_true(is.list(glmn_aug$.pred))
-  expect_equal(
-    names(glmn_aug$.pred[[1]]),
+  expect_named(
+    glmn_aug$.pred[[1]],
     c(".eval_time", ".pred_survival", ".weight_time", ".pred_censored",
-      ".weight_censored")
+      ".weight_censored"),
+    ignore.order = TRUE
   )
 })
 
@@ -118,11 +128,16 @@ test_that("augment() works for tune_results", {
   )
 
   expect_equal(nrow(aug_res), nrow(sim_tr))
-  expect_equal(names(aug_res), c(".pred", ".pred_time", "event_time", "X1", "X2"))
+  expect_named(
+    aug_res,
+    c(".pred", ".pred_time", "event_time", "X1", "X2"),
+    ignore.order = TRUE
+  )
   expect_true(is.list(aug_res$.pred))
-  expect_equal(
-    names(aug_res$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    aug_res$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
 
   expect_no_warning(
@@ -172,11 +187,16 @@ test_that("augment() works for resample_results", {
   aug_res <- augment(rs_mixed_res)
 
   expect_equal(nrow(aug_res), nrow(sim_tr))
-  expect_equal(names(aug_res), c(".pred", ".pred_time", "event_time", "X1", "X2"))
+  expect_named(
+    aug_res,
+    c(".pred", ".pred_time", "event_time", "X1", "X2"),
+    ignore.order = TRUE
+  )
   expect_true(is.list(aug_res$.pred))
-  expect_equal(
-    names(aug_res$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    aug_res$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
 })
 
@@ -215,10 +235,15 @@ test_that("augment() works for last fit", {
   aug_res <- augment(rs_mixed_res)
 
   expect_equal(nrow(aug_res), nrow(sim_te))
-  expect_equal(names(aug_res), c(".pred", ".pred_time", "event_time", "X1", "X2"))
+  expect_named(
+    aug_res,
+    c(".pred", ".pred_time", "event_time", "X1", "X2"),
+    ignore.order = TRUE
+  )
   expect_true(is.list(aug_res$.pred))
-  expect_equal(
-    names(aug_res$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    aug_res$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
 })

--- a/tests/testthat/test-survival-fit-resamples.R
+++ b/tests/testthat/test-survival-fit-resamples.R
@@ -63,9 +63,10 @@ test_that("resampling survival models with static metric", {
   # test structure of results --------------------------------------------------
 
   expect_false(".eval_time" %in% names(rs_static_res$.metrics[[1]]))
-  expect_equal(
-    names(rs_static_res$.predictions[[1]]),
-    c(".pred_time", ".row", "event_time", ".config")
+  expect_named(
+    rs_static_res$.predictions[[1]],
+    c(".pred_time", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
 
   # test metric collection -----------------------------------------------------
@@ -82,7 +83,7 @@ test_that("resampling survival models with static metric", {
     )
 
   expect_true(nrow(metric_sum) == 1)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "concordance_survival"))
 
   metric_all <- collect_metrics(rs_static_res, summarize = FALSE)
@@ -96,7 +97,8 @@ test_that("resampling survival models with static metric", {
     )
 
   expect_true(nrow(metric_all) == 10)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
+
   expect_true(all(metric_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -110,11 +112,11 @@ test_that("resampling survival models with static metric", {
   )
 
   unsum_pred <- collect_predictions(rs_static_res)
-  expect_equal(unsum_pred[0,], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr))
 
   sum_pred <- collect_predictions(rs_static_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], static_ptype[, names(static_ptype) != "id"])
+  expect_ptype(sum_pred, static_ptype[, names(static_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr))
 
 })
@@ -161,14 +163,17 @@ test_that("resampling survival models with integrated metric", {
   # test structure of results --------------------------------------------------
 
   expect_false(".eval_time" %in% names(rs_integrated_res$.metrics[[1]]))
-  expect_equal(
-    names(rs_integrated_res$.predictions[[1]]),
-    c(".pred", ".row", "event_time", ".config")
+  expect_named(
+    rs_integrated_res$.predictions[[1]],
+    c(".pred", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
+
   expect_true(is.list(rs_integrated_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(rs_integrated_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    rs_integrated_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_integrated_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -189,7 +194,7 @@ test_that("resampling survival models with integrated metric", {
     )
 
   expect_true(nrow(metric_sum) == 1)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival_integrated"))
 
   metric_all <- collect_metrics(rs_integrated_res, summarize = FALSE)
@@ -203,7 +208,7 @@ test_that("resampling survival models with integrated metric", {
     )
 
   expect_true(nrow(metric_all) == 10)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -224,17 +229,17 @@ test_that("resampling survival models with integrated metric", {
     )
 
   unsum_pred <- collect_predictions(rs_integrated_res)
-  expect_equal(unsum_pred[0,], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_integrated_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], integrated_ptype[, names(integrated_ptype) != "id"])
+  expect_ptype(sum_pred, integrated_ptype[, names(integrated_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -281,14 +286,18 @@ test_that("resampling survival models with dynamic metric", {
   # test structure of results --------------------------------------------------
 
   expect_true(".eval_time" %in% names(rs_dynamic_res$.metrics[[1]]))
-  expect_equal(
-    names(rs_dynamic_res$.predictions[[1]]),
-    c(".pred", ".row", "event_time", ".config")
+
+  expect_named(
+    rs_dynamic_res$.predictions[[1]],
+    c(".pred", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(rs_dynamic_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(rs_dynamic_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+
+  expect_named(
+    rs_dynamic_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_dynamic_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -310,7 +319,7 @@ test_that("resampling survival models with dynamic metric", {
     )
 
   expect_true(nrow(metric_sum) == length(time_points))
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival"))
 
   metric_all <- collect_metrics(rs_dynamic_res, summarize = FALSE)
@@ -325,7 +334,7 @@ test_that("resampling survival models with dynamic metric", {
     )
 
   expect_true(nrow(metric_all) == length(time_points) * nrow(sim_rs))
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -346,17 +355,17 @@ test_that("resampling survival models with dynamic metric", {
     )
 
   unsum_pred <- collect_predictions(rs_dynamic_res)
-  expect_equal(unsum_pred[0,], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_dynamic_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], dynamic_ptype[, names(dynamic_ptype) != "id"])
+  expect_ptype(sum_pred, dynamic_ptype[, names(dynamic_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -404,14 +413,16 @@ test_that("resampling survival models mixture of metric types", {
   # test structure of results --------------------------------------------------
 
   expect_true(".eval_time" %in% names(rs_mixed_res$.metrics[[1]]))
-  expect_equal(
-    names(rs_mixed_res$.predictions[[1]]),
-    c(".pred", ".row", ".pred_time", "event_time", ".config")
+  expect_named(
+    rs_mixed_res$.predictions[[1]],
+    c(".pred", ".row", ".pred_time", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(rs_mixed_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(rs_mixed_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    rs_mixed_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_mixed_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -433,7 +444,7 @@ test_that("resampling survival models mixture of metric types", {
     )
 
   expect_true(nrow(metric_sum) == length(time_points) + 2)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_sum$.eval_time)) == 2)
   expect_equal(as.vector(table(metric_sum$.metric)), c(length(time_points), 1L, 1L))
 
@@ -449,7 +460,7 @@ test_that("resampling survival models mixture of metric types", {
     )
 
   expect_true(nrow(metric_all) == (length(time_points) + 2) * nrow(sim_rs))
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(sum(is.na(metric_all$.eval_time)) == 2* nrow(sim_rs))
   expect_equal(as.vector(table(metric_all$.metric)), c(length(time_points), 1L, 1L) * nrow(sim_rs))
 
@@ -472,17 +483,17 @@ test_that("resampling survival models mixture of metric types", {
     )
 
   unsum_pred <- collect_predictions(rs_mixed_res)
-  expect_equal(unsum_pred[0,], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_mixed_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], mixed_ptype[, names(mixed_ptype) != "id"])
+  expect_ptype(sum_pred, mixed_ptype[, names(mixed_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-last-fit.R
+++ b/tests/testthat/test-survival-last-fit.R
@@ -41,12 +41,14 @@ test_that("last fit for survival models with static metric", {
 
   expect_named(
     rs_static_res,
-    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow")
+    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow"),
+    ignore.order = TRUE
   )
   expect_false(".eval_time" %in% names(rs_static_res$.metrics[[1]]))
-  expect_equal(
-    names(rs_static_res$.predictions[[1]]),
-    c(".pred_time", ".row", "event_time", ".config")
+  expect_named(
+    rs_static_res$.predictions[[1]],
+    c(".pred_time", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_s3_class(rs_static_res$.workflow[[1]], "workflow")
 
@@ -62,7 +64,7 @@ test_that("last fit for survival models with static metric", {
     )
 
   expect_true(nrow(metric_sum) == 1)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -76,11 +78,11 @@ test_that("last fit for survival models with static metric", {
   )
 
   unsum_pred <- collect_predictions(rs_static_res)
-  expect_equal(unsum_pred[0,], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_te))
 
   sum_pred <- collect_predictions(rs_static_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], static_ptype[, names(static_ptype) != "id"])
+  expect_ptype(sum_pred, static_ptype[, names(static_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_te))
 })
 
@@ -120,17 +122,20 @@ test_that("last fit for survival models with integrated metric", {
 
   expect_named(
     rs_integrated_res,
-    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow")
+    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow"),
+    ignore.order = TRUE
   )
   expect_false(".eval_time" %in% names(rs_integrated_res$.metrics[[1]]))
   expect_named(
     rs_integrated_res$.predictions[[1]],
-    c(".pred", ".row", "event_time", ".config")
+    c(".pred", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(rs_integrated_res$.predictions[[1]]$.pred))
   expect_named(
     rs_integrated_res$.predictions[[1]]$.pred[[1]],
-    c(".eval_time", ".pred_survival", ".weight_censored")
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_integrated_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -149,7 +154,7 @@ test_that("last fit for survival models with integrated metric", {
     )
 
   expect_true(nrow(metric_sum) == 1)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -170,17 +175,17 @@ test_that("last fit for survival models with integrated metric", {
     )
 
   unsum_pred <- collect_predictions(rs_integrated_res)
-  expect_equal(unsum_pred[0,], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_te))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_integrated_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], integrated_ptype[, names(integrated_ptype) != "id"])
+  expect_ptype(sum_pred, integrated_ptype[, names(integrated_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_te))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -221,17 +226,20 @@ test_that("last fit for survival models with dynamic metric", {
 
   expect_named(
     rs_dynamic_res,
-    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow")
+    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow"),
+    ignore.order = TRUE
   )
   expect_true(".eval_time" %in% names(rs_dynamic_res$.metrics[[1]]))
   expect_named(
     rs_dynamic_res$.predictions[[1]],
-    c(".pred", ".row", "event_time", ".config")
+    c(".pred", ".row", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(rs_dynamic_res$.predictions[[1]]$.pred))
   expect_named(
     rs_dynamic_res$.predictions[[1]]$.pred[[1]],
-    c(".eval_time", ".pred_survival", ".weight_censored")
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_dynamic_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -251,7 +259,7 @@ test_that("last fit for survival models with dynamic metric", {
     )
 
   expect_true(nrow(metric_sum) == length(time_points))
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -272,17 +280,17 @@ test_that("last fit for survival models with dynamic metric", {
     )
 
   unsum_pred <- collect_predictions(rs_dynamic_res)
-  expect_equal(unsum_pred[0,], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_te))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_dynamic_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], dynamic_ptype[, names(dynamic_ptype) != "id"])
+  expect_ptype(sum_pred, dynamic_ptype[, names(dynamic_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_te))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -323,17 +331,20 @@ test_that("last fit for survival models with mixture of metrics", {
 
   expect_named(
     rs_mixed_res,
-    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow")
+    c("splits", "id", ".metrics", ".notes", ".predictions", ".workflow"),
+    ignore.order = TRUE
   )
   expect_true(".eval_time" %in% names(rs_mixed_res$.metrics[[1]]))
   expect_named(
     rs_mixed_res$.predictions[[1]],
-    c(".pred", ".row", ".pred_time", "event_time", ".config")
+    c(".pred", ".row", ".pred_time", "event_time", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(rs_mixed_res$.predictions[[1]]$.pred))
   expect_named(
     rs_mixed_res$.predictions[[1]]$.pred[[1]],
-    c(".eval_time", ".pred_survival", ".weight_censored")
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     rs_mixed_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -353,7 +364,7 @@ test_that("last fit for survival models with mixture of metrics", {
     )
 
   expect_true(nrow(metric_sum) == length(time_points) + 2)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_sum$.eval_time)) == 2)
   expect_equal(as.vector(table(metric_sum$.metric)), c(length(time_points), 1L, 1L))
 
@@ -375,17 +386,17 @@ test_that("last fit for survival models with mixture of metrics", {
     )
 
   unsum_pred <- collect_predictions(rs_mixed_res)
-  expect_equal(unsum_pred[0,], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_te))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(rs_mixed_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], mixed_ptype[, names(mixed_ptype) != "id"])
+  expect_ptype(sum_pred, mixed_ptype[, names(mixed_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_te))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })

--- a/tests/testthat/test-survival-tune-autoplot.R
+++ b/tests/testthat/test-survival-tune-autoplot.R
@@ -440,12 +440,12 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_mult_grid$mapping$y),
     "~mean"
   )
-  expect_equal(
-    names(dyn_mult_grid$facet$params$rows),
+  expect_named(
+    dyn_mult_grid$facet$params$rows,
     ".metric"
   )
-  expect_equal(
-    names(dyn_mult_grid$facet$params$cols),
+  expect_named(
+    dyn_mult_grid$facet$params$cols,
     "name"
   )
   expect_snapshot(ggplot2::get_labs(dyn_mult_grid))
@@ -510,12 +510,12 @@ test_that("autoplot-ting survival models with dynamic metric", {
     rlang::expr_text(dyn_mult_marginal$mapping$y),
     "~mean"
   )
-  expect_equal(
-    names(dyn_mult_marginal$facet$params$rows),
+  expect_named(
+    dyn_mult_marginal$facet$params$rows,
     ".metric"
   )
-  expect_equal(
-    names(dyn_mult_marginal$facet$params$cols),
+  expect_named(
+    dyn_mult_marginal$facet$params$cols,
     "name"
   )
   expect_snapshot(ggplot2::get_labs(dyn_mult_marginal))

--- a/tests/testthat/test-survival-tune-autoplot.R
+++ b/tests/testthat/test-survival-tune-autoplot.R
@@ -82,7 +82,7 @@ test_that("autoplot-ting survival models with static metric", {
       name = character(0),
       value = numeric(0)
     )
-  expect_equal(exp_data_ptype, stc_marginal$data[0,])
+  expect_ptype(stc_marginal$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(stc_marginal$mapping$x),
     "~value"
@@ -108,7 +108,7 @@ test_that("autoplot-ting survival models with static metric", {
       .config = character(0),
       .iter = integer(0)
     )
-  expect_equal(exp_data_ptype, stc_perf$data[0,])
+  expect_ptype(stc_perf$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(stc_perf$mapping$x),
     "~.iter"
@@ -129,7 +129,7 @@ test_that("autoplot-ting survival models with static metric", {
       name = character(0),
       value = double(0)
     )
-  expect_equal(exp_data_ptype, stc_param$data[0,])
+  expect_ptype(stc_param$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(stc_param$mapping$x),
     "~.iter"
@@ -215,7 +215,7 @@ test_that("autoplot-ting survival models with integrated metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, int_grid$data[0,])
+  expect_ptype(int_grid$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(int_grid$mapping$x),
     "~value"
@@ -247,7 +247,7 @@ test_that("autoplot-ting survival models with integrated metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, int_marginal$data[0,])
+  expect_ptype(int_marginal$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(int_marginal$mapping$x),
     "~value"
@@ -278,7 +278,7 @@ test_that("autoplot-ting survival models with integrated metric", {
       .config = character(0),
       .iter = integer(0)
     )
-  expect_equal(exp_data_ptype, int_perf$data[0,])
+  expect_ptype(int_perf$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(int_perf$mapping$x),
     "~.iter"
@@ -299,7 +299,7 @@ test_that("autoplot-ting survival models with integrated metric", {
       name = character(0),
       value = double(0)
     )
-  expect_equal(exp_data_ptype, int_param$data[0,])
+  expect_ptype(int_param$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(int_param$mapping$x),
     "~.iter"
@@ -390,7 +390,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_grid$data[0,])
+  expect_ptype(dyn_grid$data, exp_data_ptype)
   expect_equal(
     unique(dyn_grid$data$name),
     c("Cost-Complexity Parameter (log-10)", "Minimal Node Size")
@@ -423,7 +423,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_mult_grid$data[0,])
+  expect_ptype(dyn_mult_grid$data, exp_data_ptype)
   expect_equal(
     unique(dyn_mult_grid$data$name),
     c("Cost-Complexity Parameter (log-10)", "Minimal Node Size")
@@ -463,7 +463,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_marginal$data[0,])
+  expect_ptype(dyn_marginal$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(dyn_marginal$mapping$x),
     "~value"
@@ -492,7 +492,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_mult_marginal$data[0,])
+  expect_ptype(dyn_mult_marginal$data, exp_data_ptype)
   expect_equal(
     unique(dyn_mult_marginal$data$name),
     c("Cost-Complexity Parameter (log-10)", "Minimal Node Size")
@@ -538,7 +538,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       .iter = integer(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_perf$data[0,])
+  expect_ptype(dyn_perf$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(dyn_perf$mapping$x),
     "~.iter"
@@ -568,7 +568,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       .iter = integer(0)
     )
 
-  expect_equal(exp_data_ptype, dyn_mult_perf$data[0,])
+  expect_ptype(dyn_mult_perf$data, exp_data_ptype)
   expect_equal(
     unique(dyn_mult_perf$data$.metric),
     c("brier_survival @1", "brier_survival @5")
@@ -598,7 +598,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       name = character(0),
       value = double(0)
     )
-  expect_equal(exp_data_ptype, dyn_param$data[0,])
+  expect_ptype(dyn_param$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(dyn_param$mapping$x),
     "~.iter"
@@ -624,7 +624,7 @@ test_that("autoplot-ting survival models with dynamic metric", {
       name = character(0),
       value = double(0)
     )
-  expect_equal(exp_data_ptype, dyn_mult_param$data[0,])
+  expect_ptype(dyn_mult_param$data, exp_data_ptype)
 
   expect_equal(
     rlang::expr_text(dyn_mult_param$mapping$x),
@@ -738,7 +738,7 @@ test_that("autoplot-ting survival models with different metric types", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, mix_grid$data[0,])
+  expect_ptype(mix_grid$data, exp_data_ptype)
   expect_equal(
     unique(mix_grid$data$name),
     c("Tree Depth")
@@ -775,7 +775,7 @@ test_that("autoplot-ting survival models with different metric types", {
       value = numeric(0)
     )
 
-  expect_equal(exp_data_ptype, mix_mult_grid$data[0,])
+  expect_ptype(mix_mult_grid$data, exp_data_ptype)
   expect_equal(
     unique(mix_mult_grid$data$name),
     c("Tree Depth")
@@ -803,7 +803,7 @@ test_that("autoplot-ting survival models with different metric types", {
 
   mix_marginal <- autoplot(bayes_mixed_res)
 
-  expect_equal(exp_data_ptype, mix_marginal$data[0,])
+  expect_ptype(mix_marginal$data, exp_data_ptype)
   expect_equal(
     unique(mix_marginal$data$name),
     c("Tree Depth")
@@ -832,7 +832,7 @@ test_that("autoplot-ting survival models with different metric types", {
   # multiple times
   mix_mult_marginal <- autoplot(bayes_mixed_res, eval_time = c(1, 5))
 
-  expect_equal(exp_data_ptype, mix_mult_marginal$data[0,])
+  expect_ptype(mix_mult_marginal$data, exp_data_ptype)
   expect_equal(
     unique(mix_mult_marginal$data$name),
     c("Tree Depth")
@@ -873,7 +873,7 @@ test_that("autoplot-ting survival models with different metric types", {
       .iter = integer(0)
     )
 
-  expect_equal(exp_data_ptype, mix_perf$data[0,])
+  expect_ptype(mix_perf$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(mix_perf$facet$params$facets$.metric),
     "~.metric"
@@ -911,7 +911,7 @@ test_that("autoplot-ting survival models with different metric types", {
       .iter = integer(0)
     )
 
-  expect_equal(exp_data_ptype, mix_mult_perf$data[0,])
+  expect_ptype(mix_mult_perf$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(mix_mult_perf$facet$params$facets$.metric),
     "~.metric"
@@ -942,7 +942,7 @@ test_that("autoplot-ting survival models with different metric types", {
       name = character(0),
       value = double(0)
     )
-  expect_equal(exp_data_ptype, mix_param$data[0,])
+  expect_ptype(mix_param$data, exp_data_ptype)
   expect_equal(
     rlang::expr_text(mix_param$mapping$x),
     "~.iter"

--- a/tests/testthat/test-survival-tune-bayes.R
+++ b/tests/testthat/test-survival-tune-bayes.R
@@ -66,9 +66,10 @@ test_that("Bayesian tuning survival models with static metric", {
   # test structure of results --------------------------------------------------
 
   expect_false(".eval_time" %in% names(bayes_static_res$.metrics[[1]]))
-  expect_equal(
-    names(bayes_static_res$.predictions[[1]]),
-    c(".pred_time", ".row", "event_time", "tree_depth", ".config")
+  expect_named(
+    bayes_static_res$.predictions[[1]],
+    c(".pred_time", ".row", "event_time", "tree_depth", ".config"),
+    ignore.order = TRUE
   )
 
   # test autoplot --------------------------------------------------------------
@@ -102,7 +103,7 @@ test_that("Bayesian tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_sum) == 5)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "concordance_survival"))
 
   metric_all <- collect_metrics(bayes_static_res, summarize = FALSE)
@@ -117,7 +118,7 @@ test_that("Bayesian tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_all) == 50)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -133,11 +134,11 @@ test_that("Bayesian tuning survival models with static metric", {
   )
 
   unsum_pred <- collect_predictions(bayes_static_res)
-  expect_equal(unsum_pred[0,], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
   sum_pred <- collect_predictions(bayes_static_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], static_ptype[, names(static_ptype) != "id"])
+  expect_ptype(sum_pred, static_ptype[, names(static_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
 })
@@ -202,14 +203,16 @@ test_that("Bayesian tuning survival models with integrated metric", {
   # test structure of results --------------------------------------------------
 
   expect_false(".eval_time" %in% names(bayes_integrated_res$.metrics[[1]]))
-  expect_equal(
-    names(bayes_integrated_res$.predictions[[1]]),
-    c(".pred", ".row", "event_time", "tree_depth", ".config")
+  expect_named(
+    bayes_integrated_res$.predictions[[1]],
+    c(".pred", ".row", "event_time", "tree_depth", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(bayes_integrated_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(bayes_integrated_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    bayes_integrated_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     bayes_integrated_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -246,7 +249,7 @@ test_that("Bayesian tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_sum) == 5)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival_integrated"))
 
   metric_all <- collect_metrics(bayes_integrated_res, summarize = FALSE)
@@ -261,7 +264,7 @@ test_that("Bayesian tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_all) == 50)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -284,17 +287,17 @@ test_that("Bayesian tuning survival models with integrated metric", {
     )
 
   unsum_pred <- collect_predictions(bayes_integrated_res)
-  expect_equal(unsum_pred[0,], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(bayes_integrated_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], integrated_ptype[, names(integrated_ptype) != "id"])
+  expect_ptype(sum_pred, integrated_ptype[, names(integrated_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 })
 
@@ -361,14 +364,16 @@ test_that("Bayesian tuning survival models with dynamic metric", {
   # test structure of results --------------------------------------------------
 
   expect_true(".eval_time" %in% names(bayes_dynamic_res$.metrics[[1]]))
-  expect_equal(
-    names(bayes_dynamic_res$.predictions[[1]]),
-    c(".pred", ".row", "event_time", "tree_depth", ".config")
+  expect_named(
+    bayes_dynamic_res$.predictions[[1]],
+    c(".pred", ".row", "event_time", "tree_depth", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(bayes_dynamic_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(bayes_dynamic_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    bayes_dynamic_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     bayes_dynamic_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -408,7 +413,7 @@ test_that("Bayesian tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_sum) == 20)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival"))
 
   metric_all <- collect_metrics(bayes_dynamic_res, summarize = FALSE)
@@ -424,7 +429,7 @@ test_that("Bayesian tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_all) == 200)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -447,17 +452,17 @@ test_that("Bayesian tuning survival models with dynamic metric", {
     )
 
   unsum_pred <- collect_predictions(bayes_dynamic_res)
-  expect_equal(unsum_pred[0,], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(bayes_dynamic_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], dynamic_ptype[, names(dynamic_ptype) != "id"])
+  expect_ptype(sum_pred, dynamic_ptype[, names(dynamic_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -527,14 +532,16 @@ test_that("Bayesian tuning survival models with mixture of metric types", {
   # test structure of results --------------------------------------------------
 
   expect_true(".eval_time" %in% names(bayes_mixed_res$.metrics[[1]]))
-  expect_equal(
-    names(bayes_mixed_res$.predictions[[1]]),
-    c(".pred", ".row", ".pred_time", "event_time", "tree_depth", ".config")
+  expect_named(
+    bayes_mixed_res$.predictions[[1]],
+    c(".pred", ".row", ".pred_time", "event_time", "tree_depth", ".config"),
+    ignore.order = TRUE
   )
   expect_true(is.list(bayes_mixed_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(bayes_mixed_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    bayes_mixed_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     bayes_mixed_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -578,7 +585,7 @@ test_that("Bayesian tuning survival models with mixture of metric types", {
   )
 
   expect_true(nrow(metric_sum) == 30)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_sum$.eval_time)) == 10)
   expect_equal(as.vector(table(metric_sum$.metric)), c(20L, 5L, 5L))
 
@@ -595,7 +602,7 @@ test_that("Bayesian tuning survival models with mixture of metric types", {
   )
 
   expect_true(nrow(metric_all) == 300)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(sum(is.na(metric_all$.eval_time)) == 100)
   expect_equal(as.vector(table(metric_all$.metric)), c(200L, 50L, 50L))
 
@@ -620,17 +627,17 @@ test_that("Bayesian tuning survival models with mixture of metric types", {
     )
 
   unsum_pred <- collect_predictions(bayes_mixed_res)
-  expect_equal(unsum_pred[0,], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(bayes_mixed_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], mixed_ptype[, names(mixed_ptype) != "id"])
+  expect_ptype(sum_pred, mixed_ptype[, names(mixed_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-tune-grid.R
+++ b/tests/testthat/test-survival-tune-grid.R
@@ -78,7 +78,7 @@ test_that("grid tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_sum) == 3)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "concordance_survival"))
 
   metric_all <- collect_metrics(grid_static_res, summarize = FALSE)
@@ -92,7 +92,7 @@ test_that("grid tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_all) == 30)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -107,12 +107,12 @@ test_that("grid tuning survival models with static metric", {
   )
 
   unsum_pred <- collect_predictions(grid_static_res)
-  expect_equal(unsum_pred[0, names(static_ptype)], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
   sum_pred <- collect_predictions(grid_static_res, summarize = TRUE)
   no_id <- static_ptype[, names(static_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
   # test metric collection pivoting --------------------------------------------
@@ -211,7 +211,7 @@ test_that("grid tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_sum) == 3)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival_integrated"))
 
   metric_all <- collect_metrics(grid_integrated_res, summarize = FALSE)
@@ -225,7 +225,7 @@ test_that("grid tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_all) == 30)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -247,18 +247,18 @@ test_that("grid tuning survival models with integrated metric", {
     )
 
   unsum_pred <- collect_predictions(grid_integrated_res)
-  expect_equal(unsum_pred[0, names(integrated_ptype)], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0, names(integrated_list_ptype)], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(grid_integrated_res, summarize = TRUE)
   no_id <- integrated_ptype[, names(integrated_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -365,7 +365,7 @@ test_that("grid tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_sum) == 12)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival"))
 
   metric_all <- collect_metrics(grid_dynamic_res, summarize = FALSE)
@@ -380,7 +380,7 @@ test_that("grid tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_all) == 120)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -402,17 +402,17 @@ test_that("grid tuning survival models with dynamic metric", {
     )
 
   unsum_pred <- collect_predictions(grid_dynamic_res)
-  expect_equal(unsum_pred[0,], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(grid_dynamic_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], dynamic_ptype[, names(dynamic_ptype) != "id"])
+  expect_ptype(sum_pred, dynamic_ptype[, names(dynamic_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -519,7 +519,7 @@ test_that("grid tuning survival models mixture of metric types", {
   )
 
   expect_true(nrow(metric_sum) == 18)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_sum$.eval_time)) == 6)
   expect_equal(as.vector(table(metric_sum$.metric)), c(12L, 3L, 3L))
 
@@ -535,7 +535,7 @@ test_that("grid tuning survival models mixture of metric types", {
   )
 
   expect_true(nrow(metric_all) == 180)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(sum(is.na(metric_all$.eval_time)) == 60)
   expect_equal(as.vector(table(metric_all$.metric)), c(120L, 30L, 30L))
 
@@ -559,17 +559,17 @@ test_that("grid tuning survival models mixture of metric types", {
     )
 
   unsum_pred <- collect_predictions(grid_mixed_res)
-  expect_equal(unsum_pred[0,], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(grid_mixed_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], mixed_ptype[, names(mixed_ptype) != "id"])
+  expect_equal(sum_pred, mixed_ptype[, names(mixed_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-tune-int-pctl.R
+++ b/tests/testthat/test-survival-tune-int-pctl.R
@@ -51,7 +51,7 @@ test_that("percentile internals for survival models with static metric", {
       .config = character(0)
     )
 
-  expect_equal(static_int[0,], exp_ptype)
+  expect_ptype(static_int, exp_ptype)
   expect_true(nrow(static_int) == 1)
   expect_true(all(static_int$.metric == "concordance_survival"))
 
@@ -125,7 +125,7 @@ test_that("percentile internals for survival models with integrated metric", {
       penalty = numeric(0)
     )
 
-  expect_equal(integrated_int[0, names(exp_ptype)], exp_ptype)
+  expect_ptype(integrated_int, exp_ptype)
   expect_true(nrow(integrated_int) == nrow(grid))
   expect_equal(sort(integrated_int$penalty), grid$penalty)
   expect_true(all(integrated_int$.metric == "brier_survival_integrated"))
@@ -200,7 +200,7 @@ test_that("percentile internals for survival models with dynamic metrics", {
       .eval_time = numeric(0)
     )
 
-  expect_equal(dyn_int[0,], exp_ptype)
+  expect_ptype(dyn_int, exp_ptype)
   expect_true(nrow(dyn_int) == nrow(winners))
   expect_equal(sort(dyn_int$cost_complexity), sort(winners$cost_complexity))
   expect_true(all(dyn_int$.metric == "brier_survival"))
@@ -264,7 +264,7 @@ test_that("percentile internals for survival models mixture of metric types", {
       .config = character(0)
     )
 
-  expect_equal(mixed_int[0, names(exp_ptype)], exp_ptype)
+  expect_ptype(mixed_int, exp_ptype)
   expect_true(nrow(mixed_int) == (length(time_points) + 2))
   expect_true(sum(mixed_int$.metric == "brier_survival") == length(time_points))
   expect_true(sum(mixed_int$.metric == "brier_survival_integrated") == 1)
@@ -332,7 +332,7 @@ test_that("percentile internals for subset of eval times", {
       .eval_time = numeric(0)
     )
 
-  expect_equal(mixed_int[0,], exp_ptype)
+  expect_ptype(mixed_int, exp_ptype)
   expect_true(nrow(mixed_int) == (2 + 2))
   expect_true(sum(mixed_int$.metric == "brier_survival") == 2)
   expect_true(sum(mixed_int$.metric == "brier_survival_integrated") == 1)

--- a/tests/testthat/test-survival-tune-sa.R
+++ b/tests/testthat/test-survival-tune-sa.R
@@ -110,7 +110,7 @@ test_that("sim annealing tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_sum) == 5)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "concordance_survival"))
 
   metric_all <- collect_metrics(sa_static_res, summarize = FALSE)
@@ -125,7 +125,7 @@ test_that("sim annealing tuning survival models with static metric", {
   )
 
   expect_true(nrow(metric_all) == 50)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -141,12 +141,12 @@ test_that("sim annealing tuning survival models with static metric", {
   )
 
   unsum_pred <- collect_predictions(sa_static_res)
-  expect_equal(unsum_pred[0, names(static_ptype)], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
   sum_pred <- collect_predictions(sa_static_res, summarize = TRUE)
   no_id <- static_ptype[, names(static_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
 })
@@ -224,9 +224,10 @@ test_that("sim annealing tuning survival models with integrated metric", {
     ignore.order = TRUE
   )
   expect_true(is.list(sa_integrated_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(sa_integrated_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    sa_integrated_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     sa_integrated_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -263,7 +264,7 @@ test_that("sim annealing tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_sum) == 5)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival_integrated"))
 
   metric_all <- collect_metrics(sa_integrated_res, summarize = FALSE)
@@ -278,7 +279,7 @@ test_that("sim annealing tuning survival models with integrated metric", {
   )
 
   expect_true(nrow(metric_all) == 50)
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -301,21 +302,22 @@ test_that("sim annealing tuning survival models with integrated metric", {
     )
 
   unsum_pred <- collect_predictions(sa_integrated_res)
-  expect_equal(unsum_pred[0, names(integrated_ptype)], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(sa_integrated_res, summarize = TRUE)
   no_id <- integrated_ptype[, names(integrated_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
+
 
 test_that("sim annealing tuning survival models with dynamic metric", {
   skip_if_not_installed("mboost")
@@ -435,7 +437,7 @@ test_that("sim annealing tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_sum) == (nrow(grid) + 2) * length(time_points))
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(all(metric_sum$.metric == "brier_survival"))
 
   metric_all <- collect_metrics(sa_dynamic_res, summarize = FALSE)
@@ -451,7 +453,7 @@ test_that("sim annealing tuning survival models with dynamic metric", {
   )
 
   expect_true(nrow(metric_all) == ((nrow(grid) + 2) * length(time_points)) * nrow(sim_rs))
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(all(metric_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -474,17 +476,17 @@ test_that("sim annealing tuning survival models with dynamic metric", {
     )
 
   unsum_pred <- collect_predictions(sa_dynamic_res)
-  expect_equal(unsum_pred[0,], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(sa_dynamic_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], dynamic_ptype[, names(dynamic_ptype) != "id"])
+  expect_ptype(sum_pred, dynamic_ptype[, names(dynamic_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
 })
@@ -564,9 +566,10 @@ test_that("sim annealing tuning survival models with mixture of metric types", {
     ignore.order = TRUE
   )
   expect_true(is.list(sa_mixed_res$.predictions[[1]]$.pred))
-  expect_equal(
-    names(sa_mixed_res$.predictions[[1]]$.pred[[1]]),
-    c(".eval_time", ".pred_survival", ".weight_censored")
+  expect_named(
+    sa_mixed_res$.predictions[[1]]$.pred[[1]],
+    c(".eval_time", ".pred_survival", ".weight_censored"),
+    ignore.order = TRUE
   )
   expect_equal(
     sa_mixed_res$.predictions[[1]]$.pred[[1]]$.eval_time,
@@ -611,26 +614,26 @@ test_that("sim annealing tuning survival models with mixture of metric types", {
 
   grid_size <- (nrow(grid) + 2)
   expect_true(nrow(metric_sum) == (grid_size * length(time_points)) + grid_size * 2)
-  expect_equal(metric_sum[0,], exp_metric_sum)
+  expect_ptype(metric_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_sum$.eval_time)) == 10L)
   expect_equal(as.vector(table(metric_sum$.metric)), c(20L, 5L, 5L))
 
   metric_all <- collect_metrics(sa_mixed_res, summarize = FALSE)
   exp_metric_all <- tibble(
-      id = character(0),
-      trees = numeric(0),
-      .metric = character(0),
-      .estimator = character(0),
-      .eval_time = numeric(0),
-      .estimate = numeric(0),
-      .config = character(0),
-      .iter = integer(0)
-    )
+    id = character(0),
+    trees = numeric(0),
+    .metric = character(0),
+    .estimator = character(0),
+    .eval_time = numeric(0),
+    .estimate = numeric(0),
+    .config = character(0),
+    .iter = integer(0)
+  )
 
   expect_true(nrow(metric_all) ==
                 ((nrow(grid) + 2) * length(time_points) + (nrow(grid) + 2) * 2) *
                 nrow(sim_rs))
-  expect_equal(metric_all[0,], exp_metric_all)
+  expect_ptype(metric_all, exp_metric_all)
   expect_true(sum(is.na(metric_all$.eval_time)) == 100L)
   expect_equal(as.vector(table(metric_all$.metric)), c(200L, 50L, 50L))
 
@@ -655,17 +658,17 @@ test_that("sim annealing tuning survival models with mixture of metric types", {
     )
 
   unsum_pred <- collect_predictions(sa_mixed_res)
-  expect_equal(unsum_pred[0,], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(sa_mixed_res, summarize = TRUE)
-  expect_equal(sum_pred[0,], mixed_ptype[, names(mixed_ptype) != "id"])
+  expect_ptype(sum_pred, mixed_ptype[, names(mixed_ptype) != "id"])
   expect_equal(nrow(sum_pred), nrow(sim_tr) * length(unique(unsum_pred$.config)))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-tune_race_anova.R
+++ b/tests/testthat/test-survival-tune_race_anova.R
@@ -72,8 +72,8 @@ test_that("race tuning (anova) survival models with static metric", {
 
   stc_race_plot <- plot_race(aov_static_res)
 
-  expect_equal(
-    stc_race_plot$data[0,],
+  expect_ptype(
+    stc_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -104,8 +104,8 @@ test_that("race tuning (anova) survival models with static metric", {
 
   stc_autoplot <- autoplot(aov_static_res)
 
-  expect_equal(
-    stc_autoplot$data[0,],
+  expect_ptype(
+    stc_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -154,14 +154,14 @@ test_that("race tuning (anova) survival models with static metric", {
   metric_aov_sum <- collect_metrics(aov_static_res)
 
   expect_equal(nrow(aov_finished), nrow(metric_aov_sum))
-  expect_equal(metric_aov_sum[0,], exp_metric_sum)
+  expect_ptype(metric_aov_sum, exp_metric_sum)
   expect_true(all(metric_aov_sum$.metric == "concordance_survival"))
 
   ###
 
   metric_aov_all <- collect_metrics(aov_static_res, summarize = FALSE)
   expect_true(nrow(metric_aov_all) == nrow(aov_finished) * nrow(sim_rs))
-  expect_equal(metric_aov_all[0,], exp_metric_all)
+  expect_ptype(metric_aov_all, exp_metric_all)
   expect_true(all(metric_aov_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -182,12 +182,12 @@ test_that("race tuning (anova) survival models with static metric", {
     sum()
 
   unsum_pred <- collect_predictions(aov_static_res)
-  expect_equal(unsum_pred[0, names(static_ptype)], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), static_oob * nrow(aov_finished))
 
   sum_pred <- collect_predictions(aov_static_res, summarize = TRUE)
   no_id <- static_ptype[, names(static_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(aov_finished))
 
   # test metric collection pivoting --------------------------------------------
@@ -283,8 +283,8 @@ test_that("race tuning (anova) survival models with integrated metric", {
 
   int_race_plot <- plot_race(aov_integrated_res)
 
-  expect_equal(
-    int_race_plot$data[0,],
+  expect_ptype(
+    int_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -315,8 +315,8 @@ test_that("race tuning (anova) survival models with integrated metric", {
 
   int_autoplot <- autoplot(aov_integrated_res)
 
-  expect_equal(
-    int_autoplot$data[0,],
+  expect_ptype(
+    int_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -365,14 +365,14 @@ test_that("race tuning (anova) survival models with integrated metric", {
   metric_aov_sum <- collect_metrics(aov_integrated_res)
 
   expect_equal(nrow(aov_finished), nrow(metric_aov_sum))
-  expect_equal(metric_aov_sum[0,], exp_metric_sum)
+  expect_ptype(metric_aov_sum, exp_metric_sum)
   expect_true(all(metric_aov_sum$.metric == "brier_survival_integrated"))
 
   ###
 
   metric_aov_all <- collect_metrics(aov_integrated_res, summarize = FALSE)
   expect_true(nrow(metric_aov_all) == nrow(aov_finished) * nrow(sim_rs))
-  expect_equal(metric_aov_all[0,], exp_metric_all)
+  expect_ptype(metric_aov_all, exp_metric_all)
   expect_true(all(metric_aov_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -400,19 +400,19 @@ test_that("race tuning (anova) survival models with integrated metric", {
     sum()
 
   unsum_pred <- collect_predictions(aov_integrated_res)
-  expect_equal(unsum_pred[0, names(integrated_ptype)], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), integrated_oob * nrow(aov_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0, names(integrated_list_ptype)], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
 
   sum_pred <- collect_predictions(aov_integrated_res, summarize = TRUE)
   no_id <- integrated_ptype[, names(integrated_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(aov_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -519,8 +519,8 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
 
   dyn_race_plot <- plot_race(aov_dyn_res)
 
-  expect_equal(
-    dyn_race_plot$data[0,],
+  expect_ptype(
+    dyn_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -551,8 +551,8 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
 
   dyn_autoplot <- autoplot(aov_dyn_res)
 
-  expect_equal(
-    dyn_autoplot$data[0,],
+  expect_ptype(
+    dyn_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -605,14 +605,14 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
   metric_aov_sum <- collect_metrics(aov_dyn_res)
 
   expect_equal(nrow(aov_finished) * length(time_points), nrow(metric_aov_sum))
-  expect_equal(metric_aov_sum[0,], exp_metric_sum)
+  expect_ptype(metric_aov_sum, exp_metric_sum)
   expect_true(all(metric_aov_sum$.metric == "brier_survival"))
 
   ###
 
   metric_aov_all <- collect_metrics(aov_dyn_res, summarize = FALSE)
   expect_true(nrow(metric_aov_all) == nrow(aov_finished) * nrow(sim_rs) * length(time_points))
-  expect_equal(metric_aov_all[0,], exp_metric_all)
+  expect_ptype(metric_aov_all, exp_metric_all)
   expect_true(all(metric_aov_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -640,19 +640,19 @@ test_that("race tuning (anova) survival models with dynamic metrics", {
     sum()
 
   unsum_pred <- collect_predictions(aov_dyn_res)
-  expect_equal(unsum_pred[0, names(dynamic_ptype)], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), dyn_oob * nrow(aov_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0, names(dynamic_list_ptype)], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
 
   sum_pred <- collect_predictions(aov_dyn_res, summarize = TRUE)
   no_id <- dynamic_ptype[, names(dynamic_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(aov_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -755,8 +755,8 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
 
   mix_race_plot <- plot_race(aov_mixed_res)
 
-  expect_equal(
-    mix_race_plot$data[0,],
+  expect_ptype(
+    mix_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -787,8 +787,8 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
 
   mix_autoplot <- autoplot(aov_mixed_res)
 
-  expect_equal(
-    mix_autoplot$data[0,],
+  expect_ptype(
+    mix_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -825,8 +825,8 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
 
   mix_multi_autoplot <- autoplot(aov_mixed_res, eval_time = c(1, 10))
 
-  expect_equal(
-    mix_multi_autoplot$data[0,],
+  expect_ptype(
+    mix_multi_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -862,8 +862,8 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
 
   mix_alt_autoplot <- autoplot(aov_mixed_res, metric = "concordance_survival")
 
-  expect_equal(
-    mix_alt_autoplot$data[0,],
+  expect_ptype(
+    mix_alt_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -918,7 +918,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
   metric_aov_sum <- collect_metrics(aov_mixed_res)
 
   expect_equal(nrow(aov_finished) * num_metrics, nrow(metric_aov_sum))
-  expect_equal(metric_aov_sum[0,], exp_metric_sum)
+  expect_ptype(metric_aov_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_aov_sum$.eval_time)) == 2 * nrow(aov_finished))
   expect_equal(as.vector(table(metric_aov_sum$.metric)), c(4L, 1L, 1L) * nrow(aov_finished))
 
@@ -926,7 +926,7 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
 
   metric_aov_all <- collect_metrics(aov_mixed_res, summarize = FALSE)
   expect_true(nrow(metric_aov_all) == num_metrics * nrow(aov_finished) * nrow(sim_rs))
-  expect_equal(metric_aov_all[0,], exp_metric_all)
+  expect_ptype(metric_aov_all, exp_metric_all)
   expect_true(sum(is.na(metric_aov_sum$.eval_time)) == 2 * nrow(aov_finished))
   expect_equal(as.vector(table(metric_aov_sum$.metric)), c(4L, 1L, 1L) * nrow(aov_finished))
 
@@ -956,18 +956,18 @@ test_that("race tuning (anova) survival models with mixture of metric types", {
     sum()
 
   unsum_pred <- collect_predictions(aov_mixed_res)
-  expect_equal(unsum_pred[0, names(mixed_ptype)], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), mixed_oob * nrow(aov_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(aov_mixed_res, summarize = TRUE)
   no_id <- mixed_ptype[, names(mixed_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(aov_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-tune_race_win_loss.R
+++ b/tests/testthat/test-survival-tune_race_win_loss.R
@@ -68,8 +68,8 @@ test_that("race tuning (win_loss) survival models with static metric", {
 
   stc_race_plot <- plot_race(wl_static_res)
 
-  expect_equal(
-    stc_race_plot$data[0,],
+  expect_ptype(
+    stc_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -100,8 +100,8 @@ test_that("race tuning (win_loss) survival models with static metric", {
 
   stc_autoplot <- autoplot(wl_static_res)
 
-  expect_equal(
-    stc_autoplot$data[0,],
+  expect_ptype(
+    stc_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -150,14 +150,14 @@ test_that("race tuning (win_loss) survival models with static metric", {
   metric_wl_sum <- collect_metrics(wl_static_res)
 
   expect_equal(nrow(wl_finished), nrow(metric_wl_sum))
-  expect_equal(metric_wl_sum[0,], exp_metric_sum)
+  expect_ptype(metric_wl_sum, exp_metric_sum)
   expect_true(all(metric_wl_sum$.metric == "concordance_survival"))
 
   ###
 
   metric_wl_all <- collect_metrics(wl_static_res, summarize = FALSE)
   expect_true(nrow(metric_wl_all) == nrow(wl_finished) * nrow(sim_rs))
-  expect_equal(metric_wl_all[0,], exp_metric_all)
+  expect_ptype(metric_wl_all, exp_metric_all)
   expect_true(all(metric_wl_all$.metric == "concordance_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -178,12 +178,12 @@ test_that("race tuning (win_loss) survival models with static metric", {
     sum()
 
   unsum_pred <- collect_predictions(wl_static_res)
-  expect_equal(unsum_pred[0, names(static_ptype)], static_ptype)
+  expect_ptype(unsum_pred, static_ptype)
   expect_equal(nrow(unsum_pred), static_oob * nrow(wl_finished))
 
   sum_pred <- collect_predictions(wl_static_res, summarize = TRUE)
   no_id <- static_ptype[, names(static_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(wl_finished))
 
   # test metric collection pivoting --------------------------------------------
@@ -279,8 +279,8 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
 
   int_race_plot <- plot_race(wl_integrated_res)
 
-  expect_equal(
-    int_race_plot$data[0,],
+  expect_ptype(
+    int_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -311,8 +311,8 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
 
   int_autoplot <- autoplot(wl_integrated_res)
 
-  expect_equal(
-    int_autoplot$data[0,],
+  expect_ptype(
+    int_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -361,14 +361,14 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
   metric_wl_sum <- collect_metrics(wl_integrated_res)
 
   expect_equal(nrow(wl_finished), nrow(metric_wl_sum))
-  expect_equal(metric_wl_sum[0,], exp_metric_sum)
+  expect_ptype(metric_wl_sum, exp_metric_sum)
   expect_true(all(metric_wl_sum$.metric == "brier_survival_integrated"))
 
   ###
 
   metric_wl_all <- collect_metrics(wl_integrated_res, summarize = FALSE)
   expect_true(nrow(metric_wl_all) == nrow(wl_finished) * nrow(sim_rs))
-  expect_equal(metric_wl_all[0,], exp_metric_all)
+  expect_ptype(metric_wl_all, exp_metric_all)
   expect_true(all(metric_wl_all$.metric == "brier_survival_integrated"))
 
   # test prediction collection -------------------------------------------------
@@ -396,19 +396,19 @@ test_that("race tuning (win_loss) survival models with integrated metric", {
     sum()
 
   unsum_pred <- collect_predictions(wl_integrated_res)
-  expect_equal(unsum_pred[0, names(integrated_ptype)], integrated_ptype)
+  expect_ptype(unsum_pred, integrated_ptype)
   expect_equal(nrow(unsum_pred), integrated_oob * nrow(wl_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
 
   sum_pred <- collect_predictions(wl_integrated_res, summarize = TRUE)
   no_id <- integrated_ptype[, names(integrated_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(wl_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], integrated_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], integrated_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -501,8 +501,8 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
 
   dyn_race_plot <- plot_race(wl_dyn_res)
 
-  expect_equal(
-    dyn_race_plot$data[0,],
+  expect_ptype(
+    dyn_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -533,8 +533,8 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
 
   dyn_autoplot <- autoplot(wl_dyn_res)
 
-  expect_equal(
-    dyn_autoplot$data[0,],
+  expect_ptype(
+    dyn_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -588,14 +588,14 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
   metric_wl_sum <- collect_metrics(wl_dyn_res)
 
   expect_equal(nrow(wl_finished) * length(time_points), nrow(metric_wl_sum))
-  expect_equal(metric_wl_sum[0,], exp_metric_sum)
+  expect_ptype(metric_wl_sum, exp_metric_sum)
   expect_true(all(metric_wl_sum$.metric == "brier_survival"))
 
   ###
 
   metric_wl_all <- collect_metrics(wl_dyn_res, summarize = FALSE)
   expect_true(nrow(metric_wl_all) == nrow(wl_finished) * nrow(sim_rs) * length(time_points))
-  expect_equal(metric_wl_all[0,], exp_metric_all)
+  expect_ptype(metric_wl_all, exp_metric_all)
   expect_true(all(metric_wl_all$.metric == "brier_survival"))
 
   # test prediction collection -------------------------------------------------
@@ -623,18 +623,18 @@ test_that("race tuning (win_loss) survival models with dynamic metrics", {
     sum()
 
   unsum_pred <- collect_predictions(wl_dyn_res)
-  expect_equal(unsum_pred[0, names(dynamic_ptype)], dynamic_ptype)
+  expect_ptype(unsum_pred, dynamic_ptype)
   expect_equal(nrow(unsum_pred), dyn_oob * nrow(wl_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0, names(dynamic_list_ptype)], dynamic_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(wl_dyn_res, summarize = TRUE)
   no_id <- dynamic_ptype[, names(dynamic_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(wl_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], dynamic_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], dynamic_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test metric collection pivoting --------------------------------------------
@@ -730,8 +730,8 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
 
   mix_race_plot <- plot_race(wl_mixed_res)
 
-  expect_equal(
-    mix_race_plot$data[0,],
+  expect_ptype(
+    mix_race_plot$data,
     tibble::tibble(
       .config = character(0),
       mean = numeric(0),
@@ -762,8 +762,8 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
 
   mix_autoplot <- autoplot(wl_mixed_res)
 
-  expect_equal(
-    mix_autoplot$data[0,],
+  expect_ptype(
+    mix_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -799,8 +799,8 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
 
   mix_multi_autoplot <- autoplot(wl_mixed_res, eval_time = c(1, 10))
 
-  expect_equal(
-    mix_multi_autoplot$data[0,],
+  expect_ptype(
+    mix_multi_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -836,8 +836,8 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
 
   mix_alt_autoplot <- autoplot(wl_mixed_res, metric = "concordance_survival")
 
-  expect_equal(
-    mix_alt_autoplot$data[0,],
+  expect_ptype(
+    mix_alt_autoplot$data,
     tibble::tibble(
       mean = numeric(0),
       `# resamples` = integer(0),
@@ -892,7 +892,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
   metric_wl_sum <- collect_metrics(wl_mixed_res)
 
   expect_equal(nrow(wl_finished) * num_metrics, nrow(metric_wl_sum))
-  expect_equal(metric_wl_sum[0,], exp_metric_sum)
+  expect_ptype(metric_wl_sum, exp_metric_sum)
   expect_true(sum(is.na(metric_wl_sum$.eval_time)) == 2 * nrow(wl_finished))
   expect_equal(as.vector(table(metric_wl_sum$.metric)), c(4L, 1L, 1L) * nrow(wl_finished))
 
@@ -900,7 +900,7 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
 
   metric_wl_all <- collect_metrics(wl_mixed_res, summarize = FALSE)
   expect_true(nrow(metric_wl_all) == num_metrics * nrow(wl_finished) * nrow(sim_rs))
-  expect_equal(metric_wl_all[0,], exp_metric_all)
+  expect_ptype(metric_wl_all, exp_metric_all)
   expect_true(sum(is.na(metric_wl_sum$.eval_time)) == 2 * nrow(wl_finished))
   expect_equal(as.vector(table(metric_wl_sum$.metric)), c(4L, 1L, 1L) * nrow(wl_finished))
 
@@ -930,18 +930,18 @@ test_that("race tuning (win_loss) survival models with mixture of metric types",
     sum()
 
   unsum_pred <- collect_predictions(wl_mixed_res)
-  expect_equal(unsum_pred[0, names(mixed_ptype)], mixed_ptype)
+  expect_ptype(unsum_pred, mixed_ptype)
   expect_equal(nrow(unsum_pred), mixed_oob * nrow(wl_finished))
 
-  expect_equal(unsum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(unsum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(unsum_pred$.pred[[1]]), length(time_points))
 
   sum_pred <- collect_predictions(wl_mixed_res, summarize = TRUE)
   no_id <- mixed_ptype[, names(mixed_ptype) != "id"]
-  expect_equal(sum_pred[0, names(no_id)], no_id)
+  expect_ptype(sum_pred, no_id)
   expect_equal(nrow(sum_pred), nrow(sim_tr) * nrow(wl_finished))
 
-  expect_equal(sum_pred$.pred[[1]][0,], mixed_list_ptype)
+  expect_ptype(sum_pred$.pred[[1]], mixed_list_ptype)
   expect_equal(nrow(sum_pred$.pred[[1]]), length(time_points))
 
   # test show_best() -----------------------------------------------------------

--- a/tests/testthat/test-survival-workflow-set.R
+++ b/tests/testthat/test-survival-workflow-set.R
@@ -133,7 +133,7 @@ test_that("resampling survival models with static metric", {
       std_err = numeric(0)
     )
 
-  expect_equal(wflow_set_mtrcs[0,], exp_metric_sum)
+  expect_ptype(wflow_set_mtrcs, exp_metric_sum)
 
   # test prediction collection -------------------------------------------------
 
@@ -151,7 +151,7 @@ test_that("resampling survival models with static metric", {
     event_time = survival::Surv(0, 1, type = "right")[FALSE]
   )
 
-  expect_equal(wflow_set_preds[0,], static_ptype)
+  expect_ptype(wflow_set_preds, static_ptype)
 })
 
 test_that("resampling survival models with integrated metric", {
@@ -248,7 +248,7 @@ test_that("resampling survival models with integrated metric", {
       std_err = numeric(0)
     )
 
-  expect_equal(wflow_set_mtrcs[0,], exp_metric_sum)
+  expect_ptype(wflow_set_mtrcs, exp_metric_sum)
 
   # test prediction collection -------------------------------------------------
 
@@ -266,7 +266,7 @@ test_that("resampling survival models with integrated metric", {
     event_time = survival::Surv(0, 1, type = "right")[FALSE]
   )
 
-  expect_equal(wflow_set_preds[0,], static_ptype)
+  expect_ptype(wflow_set_preds, static_ptype)
 })
 
 test_that("resampling survival models with dynamic metric", {
@@ -364,7 +364,7 @@ test_that("resampling survival models with dynamic metric", {
       std_err = numeric(0)
     )
 
-  expect_equal(wflow_set_mtrcs[0,], exp_metric_sum)
+  expect_ptype(wflow_set_mtrcs, exp_metric_sum)
 
   # test prediction collection -------------------------------------------------
 
@@ -382,7 +382,7 @@ test_that("resampling survival models with dynamic metric", {
     event_time = survival::Surv(0, 1, type = "right")[FALSE]
   )
 
-  expect_equal(wflow_set_preds[0,], static_ptype)
+  expect_ptype(wflow_set_preds, static_ptype)
 })
 
 test_that("resampling survival models with mixture of metric types", {
@@ -479,7 +479,7 @@ test_that("resampling survival models with mixture of metric types", {
       std_err = numeric(0)
     )
 
-  expect_equal(wflow_set_mtrcs[0,], exp_metric_sum)
+  expect_ptype(wflow_set_mtrcs, exp_metric_sum)
 
   # test prediction collection -------------------------------------------------
 
@@ -498,5 +498,5 @@ test_that("resampling survival models with mixture of metric types", {
     event_time = survival::Surv(0, 1, type = "right")[FALSE]
   )
 
-  expect_equal(wflow_set_preds[0,], static_ptype)
+  expect_ptype(wflow_set_preds, static_ptype)
 })

--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -113,12 +113,12 @@ test_that("can `predict()` a censored workflow with a formula", {
 
   preds <- predict(wf_fit, new_data = lung)
 
-  expect_identical(names(preds), ".pred_time")
+  expect_named(preds, ".pred_time")
   expect_type(preds$.pred_time, "double")
 
   preds <- predict(wf_fit, new_data = lung, type = "survival", eval_time = c(100, 200))
 
-  expect_identical(names(preds), ".pred")
+  expect_named(preds, ".pred")
   expect_type(preds$.pred, "list")
   expect_true(
     all(purrr::map_lgl(
@@ -149,12 +149,12 @@ test_that("can `predict()` a censored workflow with a model formula", {
 
   preds <- predict(wf_fit, new_data = lung)
 
-  expect_identical(names(preds), ".pred_time")
+  expect_named(preds, ".pred_time")
   expect_type(preds$.pred_time, "double")
 
   preds <- predict(wf_fit, new_data = lung, type = "survival", eval_time = c(100, 200))
 
-  expect_identical(names(preds), ".pred")
+  expect_named(preds, ".pred")
   expect_type(preds$.pred, "list")
   expect_true(
     all(purrr::map_lgl(
@@ -183,12 +183,12 @@ test_that("can `predict()` a censored workflow with variables", {
 
   preds <- predict(wf_fit, new_data = lung)
 
-  expect_identical(names(preds), ".pred_time")
+  expect_named(preds, ".pred_time")
   expect_type(preds$.pred_time, "double")
 
   preds <- predict(wf_fit, new_data = lung, type = "survival", eval_time = c(100, 200))
 
-  expect_identical(names(preds), ".pred")
+  expect_named(preds, ".pred")
   expect_type(preds$.pred, "list")
   expect_true(
     all(purrr::map_lgl(
@@ -219,12 +219,12 @@ test_that("can `predict()` a censored workflow with a recipe", {
 
   preds <- predict(wf_fit, new_data = lung)
 
-  expect_identical(names(preds), ".pred_time")
+  expect_named(preds, ".pred_time")
   expect_type(preds$.pred_time, "double")
 
   preds <- predict(wf_fit, new_data = lung, type = "survival", eval_time = c(100, 200))
 
-  expect_identical(names(preds), ".pred")
+  expect_named(preds, ".pred")
   expect_type(preds$.pred, "list")
   expect_true(
     all(purrr::map_lgl(

--- a/tests/testthat/test-workflows-survival-augment.R
+++ b/tests/testthat/test-workflows-survival-augment.R
@@ -43,7 +43,7 @@ test_that("augment survival workflows with eval_time", {
   )
   expect_true(is.numeric(res$.pred_time))
   expect_true(is.list(res$.pred))
-  expect_equal(res$.pred[[1]][0,], exp_pred_col)
+  expect_ptype(res$.pred[[1]], exp_pred_col)
   expect_equal(nrow(res$.pred[[2]]), length(times))
   expect_equal(res$.pred[[3]]$.eval_time, times)
 
@@ -56,7 +56,7 @@ test_that("augment survival workflows with eval_time", {
   )
   expect_true(is.numeric(res_1_row$.pred_time))
   expect_true(is.list(res_1_row$.pred))
-  expect_equal(res_1_row$.pred[[1]][0,], exp_pred_col)
+  expect_ptype(res_1_row$.pred[[1]], exp_pred_col)
   expect_equal(nrow(res_1_row$.pred[[1]]), 1)
   expect_equal(res_1_row$.pred[[1]]$.eval_time, times[1])
 


### PR DESCRIPTION
The survival tests had many ptypes and vectors of column names that failed once we changed the column order. 

We might want to make a time-based skip to amend these once we are nearly done to make them sensitive to order, but I don't think that now is the time for that action. Alternatively, we can augment with some specific tests that lock down specific column orderings. 