### PR TITLE
add test for misspelled engine names give informative error for extension packages

### DIFF
--- a/tests/testthat/_snaps/extension-misspelled-engine.md
+++ b/tests/testthat/_snaps/extension-misspelled-engine.md
@@ -1,0 +1,27 @@
+# misspelled engine names give informative error for extension packages
+
+    Code
+      set_mode(set_engine(poisson_reg(), "gml"), "regression")
+    Condition
+      Error in `set_engine()`:
+      x Engine "gml" is not supported for `poisson_reg()`.
+      i See `show_engines("poisson_reg")`.
+
+---
+
+    Code
+      set_engine(set_mode(poisson_reg(), "regression"), "gml")
+    Condition
+      Error in `set_engine()`:
+      x Engine "gml" is not supported for `poisson_reg()`.
+      i See `show_engines("poisson_reg")`.
+
+---
+
+    Code
+      set_engine(poisson_reg(), "gml")
+    Condition
+      Error in `set_engine()`:
+      x Engine "gml" is not supported for `poisson_reg()`.
+      i See `show_engines("poisson_reg")`.
+

--- a/tests/testthat/test-extension-misspelled-engine.R
+++ b/tests/testthat/test-extension-misspelled-engine.R
@@ -1,0 +1,27 @@
+test_that("misspelled engine names give informative error for extension packages", {
+  # See issue https://github.com/tidymodels/parsnip/issues/1110
+  # This test only works if poissonreg hasn't been loaded yet.
+  # It should be located before any calls to `library(poissonreg)`
+  skip_if_not_installed("poissonreg")
+  skip_if_not_installed("parsnip", "1.4.1.9004")
+
+  expect_snapshot(
+    poisson_reg() |>
+      set_engine("gml") |>
+      set_mode("regression"),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    poisson_reg() |>
+      set_mode("regression") |>
+      set_engine("gml"),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    poisson_reg() |>
+      set_engine("gml"),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Adds tests for https://github.com/tidymodels/parsnip/pull/1341