### PR TITLE
Quite warnings for glmnet v5

### DIFF
--- a/tests/testthat/_snaps/censored-case-weights.md
+++ b/tests/testthat/_snaps/censored-case-weights.md
@@ -12,5 +12,5 @@
       wt_fit$fit$call
     Output
       glmnet::glmnet(x = data_obj$x, y = data_obj$y, family = "cox", 
-          weights = weights, alpha = alpha, lambda = lambda)
+          weights = weights, alpha = alpha, lambda = lambda, cox.ties = ..1)
 

--- a/tests/testthat/_snaps/survival-tune-select.md
+++ b/tests/testthat/_snaps/survival-tune-select.md
@@ -208,7 +208,7 @@
       # A tibble: 1 x 2
         penalty .config         
           <dbl> <chr>           
-      1  0.0129 pre0_mod02_post0
+      1    0.01 pre0_mod01_post0
 
 ---
 
@@ -218,7 +218,7 @@
       # A tibble: 1 x 2
         penalty .config         
           <dbl> <chr>           
-      1  0.0129 pre0_mod02_post0
+      1    0.01 pre0_mod01_post0
 
 ---
 
@@ -231,7 +231,7 @@
       # A tibble: 1 x 2
         penalty .config         
           <dbl> <chr>           
-      1  0.0129 pre0_mod02_post0
+      1    0.01 pre0_mod01_post0
 
 ---
 

--- a/tests/testthat/_snaps/survival-tune-show-best.md
+++ b/tests/testthat/_snaps/survival-tune-show-best.md
@@ -187,9 +187,9 @@
       # A tibble: 3 x 8
            penalty .metric          .estimator  mean     n   std_err .config     .iter
              <dbl> <chr>            <chr>      <dbl> <int>     <dbl> <chr>       <int>
-      1 0.00000168 royston_survival standard   1.000    10 0.0000534 initial_pr~     0
-      2 0.0000470  royston_survival standard   1.000    10 0.0000534 Iter1           1
-      3 0.000153   royston_survival standard   1.000    10 0.0000534 Iter2           2
+      1 0.00000168 royston_survival standard   0.999    10 0.0000725 initial_pr~     0
+      2 0.0000470  royston_survival standard   0.999    10 0.0000725 Iter1           1
+      3 0.000153   royston_survival standard   0.999    10 0.0000725 Iter2           2
 
 ---
 
@@ -197,11 +197,11 @@
       show_best(sa_linpred_res, metric = "concordance_survival")
     Output
       # A tibble: 3 x 8
-           penalty .metric              .estimator  mean     n std_err .config   .iter
-             <dbl> <chr>                <chr>      <dbl> <int>   <dbl> <chr>     <int>
-      1 0.00000168 concordance_survival standard   0.938    10 0.00376 initial_~     0
-      2 0.0000470  concordance_survival standard   0.938    10 0.00376 Iter1         1
-      3 0.000153   concordance_survival standard   0.938    10 0.00376 Iter2         2
+           penalty .metric              .estimator  mean     n  std_err .config  .iter
+             <dbl> <chr>                <chr>      <dbl> <int>    <dbl> <chr>    <int>
+      1 0.00000168 concordance_survival standard   0.994    10 0.000398 initial~     0
+      2 0.0000470  concordance_survival standard   0.994    10 0.000398 Iter1        1
+      3 0.000153   concordance_survival standard   0.994    10 0.000398 Iter2        2
 
 ---
 
@@ -214,9 +214,9 @@
       # A tibble: 3 x 8
            penalty .metric          .estimator  mean     n   std_err .config     .iter
              <dbl> <chr>            <chr>      <dbl> <int>     <dbl> <chr>       <int>
-      1 0.00000168 royston_survival standard   1.000    10 0.0000534 initial_pr~     0
-      2 0.0000470  royston_survival standard   1.000    10 0.0000534 Iter1           1
-      3 0.000153   royston_survival standard   1.000    10 0.0000534 Iter2           2
+      1 0.00000168 royston_survival standard   0.999    10 0.0000725 initial_pr~     0
+      2 0.0000470  royston_survival standard   0.999    10 0.0000725 Iter1           1
+      3 0.000153   royston_survival standard   0.999    10 0.0000725 Iter2           2
 
 ---
 

--- a/tests/testthat/_snaps/survival-tune_race_anova.md
+++ b/tests/testthat/_snaps/survival-tune_race_anova.md
@@ -409,9 +409,9 @@
 ---
 
     Code
-      tune_res <- proportional_hazards(penalty = tune(), engine = "glmnet") %>%
-        tune_race_anova(surv ~ ., resamples = vfold_cv(lung_surv, 5), metrics = metric_set(
-          concordance_survival), eval_time = 10)
+      tune_res <- proportional_hazards(penalty = tune()) %>% set_engine("glmnet",
+        cox.ties = "efron") %>% tune_race_anova(surv ~ ., resamples = vfold_cv(
+        lung_surv, 5), metrics = metric_set(concordance_survival), eval_time = 10)
     Condition
       Warning in `tune_race_anova()`:
       `eval_time` is only used for dynamic or integrated survival metrics.

--- a/tests/testthat/_snaps/survival-tune_race_win_loss.md
+++ b/tests/testthat/_snaps/survival-tune_race_win_loss.md
@@ -400,7 +400,7 @@
       # A tibble: 1 x 6
         penalty .metric        .eval_time   mean     n std_err
           <dbl> <chr>               <dbl>  <dbl> <int>   <dbl>
-      1    0.01 brier_survival          1 0.0192    30 0.00158
+      1  0.0001 brier_survival          1 0.0192    30 0.00158
 
 ---
 
@@ -416,7 +416,7 @@
       # A tibble: 1 x 6
         penalty .metric          .eval_time  mean     n std_err
           <dbl> <chr>                 <dbl> <dbl> <int>   <dbl>
-      1    0.01 royston_survival         NA 0.433    30  0.0111
+      1  0.0001 royston_survival         NA 0.433    30  0.0111
 
 # race tuning (W/L) - unneeded eval_time
 
@@ -431,9 +431,9 @@
 ---
 
     Code
-      tune_res <- proportional_hazards(penalty = tune(), engine = "glmnet") %>%
-        tune_race_win_loss(surv ~ ., resamples = vfold_cv(lung_surv, 5), metrics = metric_set(
-          concordance_survival), eval_time = 10)
+      tune_res <- proportional_hazards(penalty = tune()) %>% set_engine("glmnet",
+        cox.ties = "efron") %>% tune_race_win_loss(surv ~ ., resamples = vfold_cv(
+        lung_surv, 5), metrics = metric_set(concordance_survival), eval_time = 10)
     Condition
       Warning in `tune_race_win_loss()`:
       `eval_time` is only used for dynamic or integrated survival metrics.

--- a/tests/testthat/test-censored-case-weights.R
+++ b/tests/testthat/test-censored-case-weights.R
@@ -104,7 +104,7 @@ test_that('proportional_hazards - glmnet censored case weights', {
     {
       wt_fit <-
         proportional_hazards(penalty = 0.1) %>%
-        set_engine("glmnet") %>%
+        set_engine("glmnet", cox.ties = "efron") %>%
         set_mode("censored regression") %>%
         fit(Surv(time, event) ~ ., data = dat$full, case_weights = dat$wts)
     },
@@ -113,7 +113,7 @@ test_that('proportional_hazards - glmnet censored case weights', {
 
   unwt_fit <-
     proportional_hazards(penalty = 0.1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression") %>%
     fit(Surv(time, event) ~ ., data = dat$full)
 

--- a/tests/testthat/test-survival-augment.R
+++ b/tests/testthat/test-survival-augment.R
@@ -53,7 +53,7 @@ test_that("augmenting survival models", {
 
   glmn_fit <-
     proportional_hazards(penalty = 0.1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     fit(event_time ~ ., data = sim_tr)
 
   glmn_aug <- augment(glmn_fit, new_data = sim_tr, eval_time = time_points)
@@ -110,7 +110,7 @@ test_that("augment() works for tune_results", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))

--- a/tests/testthat/test-survival-fit-resamples.R
+++ b/tests/testthat/test-survival-fit-resamples.R
@@ -387,7 +387,7 @@ test_that("resampling survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = 0.01) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   rsctrl <- control_resamples(save_pred = TRUE)
@@ -645,7 +645,7 @@ test_that("resampling survival models mixture of metric types including linear_p
 
   mod_spec <-
     proportional_hazards(penalty = 0.01) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   rsctrl <- control_resamples(save_pred = TRUE)

--- a/tests/testthat/test-survival-fit_best.R
+++ b/tests/testthat/test-survival-fit_best.R
@@ -26,7 +26,7 @@ test_that("fit best with static metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -73,7 +73,7 @@ test_that("grid tuning survival models with integrated metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -121,7 +121,7 @@ test_that("grid tuning survival models with dynamic metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -170,7 +170,7 @@ test_that("fit best with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -219,7 +219,7 @@ test_that("grid tuning survival models mixture of metric types", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))

--- a/tests/testthat/test-survival-last-fit.R
+++ b/tests/testthat/test-survival-last-fit.R
@@ -317,7 +317,7 @@ test_that("last fit for survival models with linear_pred metric", {
   set.seed(2193)
   rs_linpred_res <-
     proportional_hazards(penalty = 0.01) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     last_fit(
       event_time ~ X1 + X2,
       split = split,

--- a/tests/testthat/test-survival-tune-autoplot.R
+++ b/tests/testthat/test-survival-tune-autoplot.R
@@ -168,9 +168,9 @@ test_that("autoplot-ting survival models with integrated metric", {
   mod_spec <-
     proportional_hazards(
       penalty = tune(),
-      mixture = tune(),
-      engine = "glmnet"
+      mixture = tune()
     ) %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <-
@@ -995,7 +995,8 @@ test_that("autoplot() warning for unneeded evaluation times", {
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
   set.seed(2193)
   tune_res <-
-    proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+    proportional_hazards(penalty = tune()) %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     tune_grid(
       surv ~ .,
       resamples = vfold_cv(lung_surv, 2),

--- a/tests/testthat/test-survival-tune-bayes.R
+++ b/tests/testthat/test-survival-tune-bayes.R
@@ -503,7 +503,7 @@ test_that("Bayesian tuning survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -795,7 +795,7 @@ test_that("Bayesian tuning survival models with mixture of metric types includin
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))

--- a/tests/testthat/test-survival-tune-case-weights.R
+++ b/tests/testthat/test-survival-tune-case-weights.R
@@ -19,7 +19,7 @@ test_that("grid tuning survival models with importance case weights", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet", path_values = grid$penalty) %>%
+    set_engine("glmnet", path_values = grid$penalty, cox.ties = "efron") %>%
     set_mode("censored regression")
 
   gctrl <- control_grid(save_pred = TRUE, extract = function(x) {
@@ -116,7 +116,7 @@ test_that("grid tuning survival models with frequency case weights", {
 
   mod_spec <-
     proportional_hazards(penalty = 0.01, mixture = 1) %>%
-    set_engine("glmnet", path_values = grid$penalty) %>%
+    set_engine("glmnet", path_values = grid$penalty, cox.ties = "efron") %>%
     set_mode("censored regression")
 
   rctrl <- control_resamples(extract = function(x) extract_fit_engine(x))
@@ -175,7 +175,7 @@ test_that("grid tuning survival models with frequency case weights", {
       control = rctrl
     )
 
-  expect_identical(
+  expect_equal(
     coef(weights_none_tune_res$.extracts[[1]]$.extracts[[1]]),
     coef(weights_frq_tune_res$.extracts[[1]]$.extracts[[1]])
   )

--- a/tests/testthat/test-survival-tune-compute-metrics.R
+++ b/tests/testthat/test-survival-tune-compute-metrics.R
@@ -24,7 +24,8 @@ test_that("compute_metrics works with survival models", {
 
   set.seed(2193)
   tune_res <-
-    proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+    proportional_hazards(penalty = tune()) %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     tune_grid(
       surv ~ .,
       resamples = vfold_cv(lung_surv, 2),

--- a/tests/testthat/test-survival-tune-grid.R
+++ b/tests/testthat/test-survival-tune-grid.R
@@ -26,7 +26,7 @@ test_that("grid tuning survival models with static metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -155,7 +155,7 @@ test_that("grid tuning survival models with integrated metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -307,7 +307,7 @@ test_that("grid tuning survival models with dynamic metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -468,7 +468,7 @@ test_that("grid tuning survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -590,7 +590,7 @@ test_that("grid tuning survival models mixture of metric types", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))

--- a/tests/testthat/test-survival-tune-int-pctl.R
+++ b/tests/testthat/test-survival-tune-int-pctl.R
@@ -91,7 +91,7 @@ test_that("percentile internals for survival models with integrated metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = c(0.01, 0.1))

--- a/tests/testthat/test-survival-tune-sa.R
+++ b/tests/testthat/test-survival-tune-sa.R
@@ -356,7 +356,7 @@ test_that("sim annealing tuning survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -855,7 +855,7 @@ test_that("sim annealing tuning survival models mixture of metric types includin
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))

--- a/tests/testthat/test-survival-tune-select.R
+++ b/tests/testthat/test-survival-tune-select.R
@@ -27,7 +27,7 @@ test_that("select_*() with static metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^seq(-2, -1, length.out = 10))
@@ -105,7 +105,7 @@ test_that("grid tuning survival models with integrated metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^seq(-2, -1, length.out = 10))
@@ -183,7 +183,7 @@ test_that("grid tuning survival models with dynamic metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^seq(-2, -1, length.out = 10))
@@ -276,7 +276,7 @@ test_that("select_*() with linear pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^seq(-2, -1, length.out = 10))
@@ -351,7 +351,7 @@ test_that("grid tuning survival models mixture of metric types", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^seq(-2, -1, length.out = 10))

--- a/tests/testthat/test-survival-tune-show-best.R
+++ b/tests/testthat/test-survival-tune-show-best.R
@@ -267,7 +267,7 @@ test_that("show_best with censored data - linpred metric (+stc) - SA", {
 
   ph_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   linpred_met <- metric_set(royston_survival, concordance_survival)

--- a/tests/testthat/test-survival-tune_race_anova.R
+++ b/tests/testthat/test-survival-tune_race_anova.R
@@ -709,7 +709,7 @@ test_that("race tuning (anova) survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -1172,7 +1172,7 @@ test_that("race tuning (anova) survival models mixture of metric types including
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -1328,7 +1328,8 @@ test_that("race tuning (anova) - unneeded eval_time", {
   set.seed(2193)
   expect_snapshot(
     tune_res <-
-      proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+      proportional_hazards(penalty = tune()) %>%
+      set_engine("glmnet", cox.ties = "efron") %>%
       tune_race_anova(
         surv ~ .,
         resamples = vfold_cv(lung_surv, 5),

--- a/tests/testthat/test-survival-tune_race_win_loss.R
+++ b/tests/testthat/test-survival-tune_race_win_loss.R
@@ -685,7 +685,7 @@ test_that("race tuning (win_loss) survival models with linear_pred metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -1135,7 +1135,7 @@ test_that("race tuning (win_loss) survival models mixture of metric types includ
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -1288,7 +1288,8 @@ test_that("race tuning (W/L) - unneeded eval_time", {
   set.seed(2193)
   expect_snapshot(
     tune_res <-
-      proportional_hazards(penalty = tune(), engine = "glmnet") %>%
+      proportional_hazards(penalty = tune()) %>%
+      set_engine("glmnet", cox.ties = "efron") %>%
       tune_race_win_loss(
         surv ~ .,
         resamples = vfold_cv(lung_surv, 5),

--- a/tests/testthat/test-survival-workflow-set-fit_best.R
+++ b/tests/testthat/test-survival-workflow-set-fit_best.R
@@ -27,7 +27,7 @@ test_that("fit best with static metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -79,7 +79,7 @@ test_that("grid tuning survival models with integrated metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -132,7 +132,7 @@ test_that("grid tuning survival models with dynamic metric", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -186,7 +186,7 @@ test_that("fit best with linear_pred metric", {
 
   spec_ph <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   spec_sr <-
@@ -243,7 +243,7 @@ test_that("grid tuning survival models mixture of metric types", {
 
   mod_spec <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   grid <- tibble(penalty = 10^c(-4, -2, -1))
@@ -303,7 +303,7 @@ test_that("fit best mixture of metric types including linear_pred", {
 
   spec_ph <-
     proportional_hazards(penalty = tune(), mixture = 1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   spec_sr <-

--- a/tests/testthat/test-survival-workflow-set.R
+++ b/tests/testthat/test-survival-workflow-set.R
@@ -32,7 +32,7 @@ test_that("resampling survival models with static metric", {
 
   spec_ph <-
     proportional_hazards(penalty = .5) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   # putting together a workflow set --------------------------------------------
@@ -178,7 +178,7 @@ test_that("resampling survival models with integrated metric", {
 
   spec_ph <-
     proportional_hazards(penalty = .5) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   # putting together a workflow set --------------------------------------------
@@ -293,7 +293,7 @@ test_that("resampling survival models with dynamic metric", {
 
   spec_ph <-
     proportional_hazards(penalty = .5) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   # putting together a workflow set --------------------------------------------
@@ -405,7 +405,7 @@ test_that("resampling survival models with linear_pred metric", {
 
   spec_ph <-
     proportional_hazards(penalty = .1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   spec_sr <-
@@ -535,7 +535,7 @@ test_that("resampling survival models with mixture of metric types", {
 
   spec_ph <-
     proportional_hazards(penalty = .5) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   # putting together a workflow set --------------------------------------------
@@ -655,7 +655,7 @@ test_that("resampling survival models mixture of metric types including linear_p
 
   spec_ph <-
     proportional_hazards(penalty = .1) %>%
-    set_engine("glmnet") %>%
+    set_engine("glmnet", cox.ties = "efron") %>%
     set_mode("censored regression")
 
   spec_sr <-

--- a/tests/testthat/test-survival-workflows.R
+++ b/tests/testthat/test-survival-workflows.R
@@ -10,7 +10,8 @@ test_that("can `fit()` a censored workflow with a formula", {
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_formula(workflow, surv ~ .)
@@ -23,7 +24,7 @@ test_that("can `fit()` a censored workflow with a formula", {
   skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_identical(
     wf_fit$fit$fit$fit$beta,
-    censored::coxnet_train(surv ~ ., data = lung)$fit$beta
+    censored::coxnet_train(surv ~ ., data = lung, cox.ties = "efron")$fit$beta
   )
 })
 
@@ -58,7 +59,8 @@ test_that("can `fit()` a censored workflow with variables", {
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_variables(
@@ -75,7 +77,7 @@ test_that("can `fit()` a censored workflow with variables", {
   skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_identical(
     wf_fit$fit$fit$fit$beta,
-    censored::coxnet_train(surv ~ ., data = lung)$fit$beta
+    censored::coxnet_train(surv ~ ., data = lung, cox.ties = "efron")$fit$beta
   )
 })
 
@@ -86,7 +88,8 @@ test_that("can `fit()` a censored workflow with a recipe", {
 
   rec <- recipes::recipe(surv ~ ., lung)
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_recipe(workflow, rec)
@@ -99,7 +102,7 @@ test_that("can `fit()` a censored workflow with a recipe", {
   skip_if_not_installed("censored", minimum_version = "0.2.0.9001")
   expect_identical(
     wf_fit$fit$fit$fit$beta,
-    censored::coxnet_train(surv ~ ., data = lung)$fit$beta
+    censored::coxnet_train(surv ~ ., data = lung, cox.ties = "efron")$fit$beta
   )
 })
 
@@ -108,7 +111,8 @@ test_that("can `predict()` a censored workflow with a formula", {
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_formula(workflow, surv ~ .)
@@ -183,7 +187,8 @@ test_that("can `predict()` a censored workflow with variables", {
     tidyr::drop_na() %>%
     dplyr::mutate(surv = Surv(time, status), .keep = "unused")
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_variables(
@@ -226,7 +231,8 @@ test_that("can `predict()` a censored workflow with a recipe", {
 
   rec <- recipes::recipe(surv ~ ., lung)
 
-  mod <- proportional_hazards(engine = "glmnet", penalty = 0.1)
+  mod <- proportional_hazards(penalty = 0.1) %>%
+    set_engine("glmnet", cox.ties = "efron")
 
   workflow <- workflow()
   workflow <- add_recipe(workflow, rec)

--- a/tests/testthat/test-workflows-survival-augment.R
+++ b/tests/testthat/test-workflows-survival-augment.R
@@ -71,7 +71,8 @@ test_that("augment survival workflows with eval_time", {
   expect_snapshot(
     workflow() %>%
       add_model(
-        proportional_hazards(penalty = 0.001) %>% set_engine("glmnet")
+        proportional_hazards(penalty = 0.001) %>%
+          set_engine("glmnet", cox.ties = "efron")
       ) %>%
       add_formula(event_time ~ .) %>%
       fit(data = sim_dat) %>%


### PR DESCRIPTION
glmnet v5 warns about a change in default for `cox.ties` coming in v5.1.

Setting the arguments quites the warning. We could set it only where we explicitly capture warnings, like in snapshot tests. I've set it everywhere because otherwise this generates a lot of noise in our testthat output, making other changes harder to spot. 

Once glmnet actually changes the default, we can remove the explicit argument setting again.